### PR TITLE
1.9.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,30 @@
 [comment]: <> (Modele pdf)
 [comment]: <> (Harmoniser les constantes du module)
 
+### 1.9.0
+- NEW : Revert mode on verifications - a checked component can be un-checked in one click during an ongoing verification (the green "checked" button turns into "undo check" on hover); the verified counter is kept in sync. Works in card and list views, instant and manual modes.
+- NEW : When closing a verification with components left uncontrolled, a Yes/No confirmation pop-up ("Warning, some components have not been controlled. Do you want to continue?") is shown.
+- MAJ : PDF export now starts each component (organe) on a new page, so a table is no longer split across pages when avoidable (a single table larger than one page still spans, by necessity); the first component stays under the header on page 1.
+- FIX : PDF export - a table spanning several pages now keeps its navy outer border on every page and repeats the column headers on each page (previously the border was missing on large tables).
+- FIX : PDF export - row heights now match the actual rendering (computed from the real number of wrapped lines), fixing truncated cells, uneven row spacing and a stray artifact left under a table at a page break.
+- FIX : Excel export - long header labels (e.g. "Référentiel de conformité") now wrap inside the label column instead of being cut.
+- MAJ : Excel export - all tables now share the same fixed total width (columns distributed to a constant width instead of auto-sized), including the consolidated sheet where shorter components fill the width by merging their last column. Text columns wrap and row height adapts to the content, so nothing is cut or overflows.
+- NEW : Each verification now stores a snapshot of its park data at close time; Excel/PDF exports of a past verification reflect the data as it was then, no longer the current live data. Verifications closed before this version (no snapshot) still fall back to live data.
+- NEW : Repair page can rebuild snapshots for past verifications from the historical XLSX reports stored in each intervention (preview + apply); exports of old verifications then show the original header (technician/sales rep/client) and items. Also available via scripts/backport_snapshots.php.
+- MAJ : "Force default value on verification" now also resets a field whose default value is empty (the field is cleared) - e.g. to wipe the "Observations" field at each new verification.
+- NEW : Park items are now displayed in numbering order (autonumber field) by default; only items moved manually (drag & drop) keep their fixed position. New items are inserted at their numbering position instead of at the end. Dragging a pinned item back to its numbering position automatically un-pins it.
+- MAJ : Migration preserves existing manual arrangements - parcs whose saved order already matched their creation order are switched to numbering order, while parcs that had been reordered manually keep their layout (items pinned).
+- NEW : "Compliance framework" field (APSAD R4 / Code du Travail) added to the thirdparty GestionParc tab, editable inline (pencil).
+- NEW : At least one compliance framework must be checked on the thirdparty to close (validate) a verification.
+- NEW : The compliance framework is snapshotted onto the intervention extrafield at verification close (visible/editable on the intervention card).
+- MAJ : Excel and PDF exports now display the compliance framework at the bottom of the header (read from the intervention snapshot, fallback to the thirdparty).
+- NEW : "Plan type" field (Plan de sécurité / Plan d'intervention / Plan d'évacuation / Sans) with the exact same behaviour as the compliance framework (thirdparty tab, validation requirement, intervention snapshot, exports header).
+- NEW : Sales representative and technician are now stored as intervention extrafields, set at verification close and editable inline (pencil) per field from the GestionParc tab and the intervention card.
+- NEW : Defaults at verification start - sales rep and technician are both carried over from the previous intervention (so launching a verification no longer overrides the displayed choice); fallback to the thirdparty's current sales rep / the current user when empty.
+- NEW : Existing interventions are backfilled (empty values only) - technician from the validator, sales rep from the thirdparty's current sales rep.
+- MAJ : Excel and PDF exports now rely on these stored values (fallback to legacy behaviour when empty).
+- FIX : Export title now shows the intervention year instead of the current year.
+
 ### 1.8.4
 - NEW : Card edit mode during verifications is now loaded via AJAX to prevent page reloads.
 - NEW : Cloned cards now automatically open in edit mode to easily apply changes.
@@ -154,4 +178,4 @@
 ### 1.0 (16/03/2022)
 - Module permettant de créer des parcs clients et créer des interventions sur ces parcs.
 - Traductible  100%
-- Box Accueil : Suivi du nombre de parcs, nombre total d'items 
+- Box Accueil : Suivi du nombre de parcs, nombre total d'items

--- a/admin/repair.php
+++ b/admin/repair.php
@@ -114,6 +114,20 @@ if($action == 'repairmoduletable') :
     endforeach;
 endif;
 
+// BACKPORT DES SNAPSHOTS DE VERIFICATION (a partir des rapports XLSX historiques)
+$backport_stats = null;
+$backport_commit = false;
+if ($action == 'backport_dryrun' || $action == 'backport_commit') :
+    if (GETPOST('token') != $_SESSION['token']) :
+        setEventMessages($langs->trans('SecurityTokenHasExpiredSoActionHasBeenCanceledPleaseRetry'), null, 'warnings');
+    else:
+        $backport_commit = ($action == 'backport_commit');
+        $backport_force = GETPOST('backport_force') ? true : false;
+        $gpverif_bp = new GestionParcVerif($db);
+        $backport_stats = $gpverif_bp->backportSnapshots($backport_commit, $backport_force);
+    endif;
+endif;
+
 /***************************************************
 * VIEW
 ****************************************************/
@@ -169,6 +183,50 @@ llxHeader('', $langs->transnoentities('gp_repairTitle').' :: '.$langs->transnoen
     <?php if($action == 'repairmoduletable' && $success == count($array_repair)) : ?>
         <div class="dolpgs-messagebox box-success right"><?php echo $langs->trans('gp_repairSuccessMsg'); ?> <i class="paddingleft fas fa-check"></i></div>
     <?php endif; ?>
+
+    <!-- BACKPORT DES SNAPSHOTS DE VERIFICATION -->
+    <form enctype="multipart/form-data" action="<?php print $_SERVER["PHP_SELF"]; ?>" method="post" style="margin-top:24px;">
+        <input type="hidden" name="token" value="<?php echo newToken(); ?>">
+
+        <table class="dolpgs-table">
+            <tbody>
+                <tr class="dolpgs-thead noborderside">
+                    <th colspan="2"><?php echo $langs->trans('gp_backportTitle'); ?></th>
+                    <th class="right" style="white-space:nowrap;">
+                        <button type="submit" name="action" value="backport_dryrun" class="dolpgs-btn btn-sm"><?php echo $langs->trans('gp_backportDryRun'); ?></button>
+                        <button type="submit" name="action" value="backport_commit" class="dolpgs-btn btn-primary btn-sm"><?php echo $langs->trans('gp_backportRun'); ?></button>
+                    </th>
+                </tr>
+                <tr class="dolpgs-tbody">
+                    <td colspan="3" class="pgsz-optiontable-fielddesc"><?php echo $langs->trans('gp_backportDesc'); ?>
+                        <label style="display:inline-block;margin-left:12px;"><input type="checkbox" name="backport_force" value="1"> <?php echo $langs->trans('gp_backportForce'); ?></label>
+                    </td>
+                </tr>
+                <?php if(is_array($backport_stats)) :
+                    $bp_labels = array(
+                        'total'=>'gp_backportStatTotal','parsed'=>'gp_backportStatParsed','written'=>'gp_backportStatWritten',
+                        'skipped_has'=>'gp_backportStatSkipped','no_xlsx'=>'gp_backportStatNoXlsx','parse_empty'=>'gp_backportStatEmpty','suspect_mtime'=>'gp_backportStatSuspect',
+                    );
+                    foreach($bp_labels as $k=>$lk) : ?>
+                        <tr class="dolpgs-tbody">
+                            <td class="bold pgsz-optiontable-fieldname"><?php echo $langs->trans($lk); ?></td>
+                            <td class="pgsz-optiontable-fielddesc"><?php echo (int) $backport_stats[$k]; ?></td>
+                            <td class="right pgsz-optiontable-field"></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    <tr class="dolpgs-tbody">
+                        <td colspan="3" class="right">
+                            <?php if($backport_commit) : ?>
+                                <span class="dolpgs-color-success bold"><?php echo $langs->trans('gp_backportDoneCommit', (int) $backport_stats['written']); ?> <i class="fas fa-check"></i></span>
+                            <?php else: ?>
+                                <span class="opacitymedium"><?php echo $langs->trans('gp_backportDoneDryRun'); ?></span>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endif; ?>
+            </tbody>
+        </table>
+    </form>
 
 </div>
 

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -28,6 +28,17 @@ endif;
 if (!$user->hasRight('gestionparc','parc','setup')) : accessforbidden();
 endif;
 
+// Provisionne l'extrafield societe "Référentiel de conformité" (upgrade-safe, idempotent)
+$gpsetup = new GestionParcVerif($db);
+$gpsetup->ensureSocieteExtrafields();
+
+// Ajoute la colonne report_snapshot à la table des vérifs (instantané des données à la clôture)
+$gpsetup->ensureVerifSnapshotColumn();
+
+// Ajoute la colonne manual_position aux tables par-parc (tri par défaut sur la numérotation)
+$gpparc = new GestionParc($db);
+$gpparc->ensureManualPositionColumn();
+
 /*******************************************************************
 * FONCTIONS
 ********************************************************************/
@@ -58,8 +69,12 @@ if ($action == 'set_options') :
             $extras_fichinter = $extrafields->fetch_name_optionals_label('fichinter');
 
             if(!array_key_exists('gestionparc_isverif', $extras_fichinter)) :
-                $extrafields->addExtraField('gestionparc_isverif', 'gp_extrafieldFichInter_isverif', 'int', '100', '', 'fichinter', 0, 0, 'null', '', 0, '', '0', '', '', $conf->entity, 'gestionparc@gestionparc');
+                $extrafields->addExtraField('gestionparc_isverif', 'gp_extrafieldFichInter_isverif', 'int', '100', '', 'fichinter', 0, 0, 'null', '', 0, '', '0', '', '', '', 'gestionparc@gestionparc');
             endif;
+
+            // Extrafields commercial / intervenant (création ou migration) + backfill
+            $verifsetup = new GestionParcVerif($db);
+            $verifsetup->ensureInterventionExtrafields();
 
             if(!$gestionparc->setVerifMode('add')) : $error++;
             endif;

--- a/ajax/manage-items.php
+++ b/ajax/manage-items.php
@@ -44,16 +44,32 @@ $action = GETPOST('action', 'alpha');
 $parckey = GETPOST('parckey', 'alphanohtml');
 $results = array();
 
+// S'assure que la colonne manual_position existe (upgrade-safe) avant toute écriture d'ordre
+$gestionparc->ensureManualPositionColumnForParc($parckey);
+
 // ITEM SORT
 if ($action == 'itemsort'){
 	$itemSort = GETPOST('itemsort', 'array');
+	$movedRaw = GETPOST('moveditem', 'alphanohtml');
+	$movedID = (int) str_replace('item-', '', $movedRaw);
 	if (!empty($itemSort)) {
-		$i = 0;
+		$i = 0; $movedIndex = 0;
 		foreach ($itemSort as $item) {
 			$i++;
-			$itemID = str_replace('item-', '', $item);
+			$itemID = (int) str_replace('item-', '', $item);
 			$rr = $gestionparc->setElementPosition($parckey, $itemID, $i);
 			$results[$i]= $rr;
+			if ($itemID === $movedID) $movedIndex = $i;
+		}
+		// L'élément déplacé est épinglé (garde sa position) SAUF s'il retombe à sa
+		// position naturelle (ordre de numérotation) : dans ce cas il est désépinglé
+		// et suit de nouveau la numérotation. Les autres éléments ne changent pas d'état.
+		if ($movedID > 0 && $movedIndex > 0) {
+			if ($gestionparc->isAtNaturalPosition($parckey, $movedID, $movedIndex)) {
+				$gestionparc->setElementManual($parckey, $movedID, 0);
+			} else {
+				$gestionparc->setElementManual($parckey, $movedID, 1);
+			}
 		}
 	}
 }

--- a/ajax/verify-items.php
+++ b/ajax/verify-items.php
@@ -33,6 +33,8 @@ if (GETPOST('token') != $_SESSION['token']) {
 $gestionparc = new GestionParc($db);
 if (isModEnabled('intervention')) {
 	$verification = new GestionParcVerif($db);
+	// Charge la vérif en cours pour que rowid soit défini (compteur nb_verified à jour)
+	$verification->isVerif($socid);
 }
 
 header('Content-Type: application/json');
@@ -68,6 +70,23 @@ switch ($action) {
 			} else {
 				echo json_encode(array('success' => false, 'error' => 'Verification failed'));
 			}
+		}
+		break;
+
+	case 'set_line_unverify':
+		$error = 0;
+		if (empty($socid))  { echo json_encode(array('success' => false, 'error' => 'Missing socid')); exit; }
+		if (empty($itemid)) { echo json_encode(array('success' => false, 'error' => 'Missing itemid')); exit; }
+		if (empty($parcid)) { echo json_encode(array('success' => false, 'error' => 'Missing parcid')); exit; }
+
+		$gestionparc->fetch_parcType($parcid);
+		if ($verification->setLineCheck($socid, $gestionparc->parc_key, $itemid, 0, $verification->rowid)) {
+			echo json_encode(array(
+				'success' => true,
+				'message' => $langs->trans('gp_verifline_reverted')
+			));
+		} else {
+			echo json_encode(array('success' => false, 'error' => 'Revert failed'));
 		}
 		break;
 

--- a/assets/css/gestionparc.css
+++ b/assets/css/gestionparc.css
@@ -153,13 +153,19 @@
 .park-item-wrapper .park-item .park-item-content .park-field .park-field-value {color: var(--gp-text-color-lighter);}
 
 .park-item-wrapper .park-item .button-sets {display: flex;gap:16px;margin-top: 24px;}
-.park-item-wrapper .park-item .button-sets .button-edit {flex:1;padding:8px;text-align:center;border-radius:4px;font-size:0.85em;text-transform:uppercase;font-weight:500;display: block;border: none; outline: none;background: transparent;}
+.park-item-wrapper .park-item .button-sets .button-edit {flex:1;padding:8px;text-align:center;border-radius:4px;font-size:0.85em;text-transform:uppercase;font-weight:500;display: block;border: none; outline: none;background: transparent;cursor: pointer;}
 .park-item-wrapper .park-item .button-sets .button-edit.button-cancel {background: var(--gp-error-color);color: #fff;}
 .park-item-wrapper .park-item .button-sets .button-edit.button-valid {background: #25a580;color: #fff;}
-.park-item-wrapper .park-item .button-verify {padding:8px;text-align:center;border-radius:4px;font-size:0.85em;text-transform:uppercase;font-weight:500;display: block;}
+.park-item-wrapper .park-item .button-verify {padding:8px;text-align:center;border-radius:4px;font-size:0.85em;text-transform:uppercase;font-weight:500;display: block;cursor: pointer;}
 .park-item-wrapper .park-item .button-verify.verified {background:rgba(40, 167, 69, 0.2);color:#28a745;}
 .park-item-wrapper .park-item .button-verify.unverified {background:#bc9526; color:#fff;}
 .park-item-wrapper .park-item .button-verify.unverified:hover {text-decoration: none;background:#3f4347;}
+/* Élément vérifié : cliquable pour revenir en arrière (revert) */
+.park-item-wrapper .park-item .button-verify.verified {cursor:pointer;transition:background .15s ease,color .15s ease;}
+.park-item-wrapper .park-item .button-verify.verified .gp-revert-hint {display:none;}
+.park-item-wrapper .park-item .button-verify.verified:hover {text-decoration:none;background:rgba(220,53,69,0.12);color:#dc3545;}
+.park-item-wrapper .park-item .button-verify.verified:hover .gp-verified-label {display:none;}
+.park-item-wrapper .park-item .button-verify.verified:hover .gp-revert-hint {display:inline;}
 
 .park-item-wrapper .park-item .grabbable {cursor: move; cursor: grab; cursor: -moz-grab; cursor: -webkit-grab;}
 .park-item-wrapper .park-item .grabbable:active {cursor: grabbing;cursor: -moz-grabbing;cursor: -webkit-grabbing;}
@@ -392,4 +398,37 @@ div.mesgs div.errors {
 @keyframes slideUp {
     from { transform: translateY(20px); opacity: 0; }
     to { transform: translateY(0); opacity: 1; }
+}
+
+/* ── Modale de confirmation (cohérente avec la modale d'export) ──── */
+.gp-modal-container.gp-modal-sm { max-width: 460px; }
+
+/* Icône d'avertissement discrète, dans la teinte navy du module */
+.gp-modal-body .gp-modal-desc .fa-exclamation-triangle {
+    color: #173652;
+    font-size: 1.1em;
+}
+
+/* Pied de modale : annuler à gauche, action à droite */
+.gp-modal-footer.gp-modal-footer-split {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+/* Bouton d'action principal (navy, identité du module) */
+.gp-modal-btn-primary {
+    background: #173652 !important;
+    color: #fff !important;
+    border: 1px solid #173652 !important;
+    border-radius: 6px;
+    padding: 7px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.18s ease, box-shadow 0.18s ease;
+}
+
+.gp-modal-btn-primary:hover {
+    background: #0f263b !important;
+    box-shadow: 0 4px 12px -3px rgba(23, 54, 82, 0.5);
 }

--- a/class/gestionparc.class.php
+++ b/class/gestionparc.class.php
@@ -30,6 +30,7 @@ class GestionParc
     public $fields;
     public $error = '';
     public $enabled;
+    public $numeroFieldCache = array();
 
     // todo: public $lines
 
@@ -110,6 +111,7 @@ class GestionParc
                  'date_creation' => array('type'=>'datetime','value'=>'','null'=>'NOT NULL','extra'=> 'DEFAULT CURRENT_TIMESTAMP'),
                  'tms' => array('type'=>'datetime','value'=>'','null'=>'NOT NULL','extra'=> 'DEFAULT CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP'),
                  'position'=> array('type'=>'int','value'=>'11','null'=>'NOT NULL','extra'=> '', 'default' => 0),
+                 'manual_position'=> array('type'=>'BOOLEAN','null'=>'NOT NULL','extra'=> 'DEFAULT 0'),
                 );
 
                 // ON VERIFIE SI LE MODE VERIF EST ACTIF POUR CREER LA COLONNE
@@ -485,22 +487,205 @@ class GestionParc
 
         $sql = "SELECT * FROM ".MAIN_DB_PREFIX.$this->table_element.'__'.$parc_key;
         $sql .= " WHERE socid = '".$socid."'";
-        $sql .= " ORDER BY position ASC";
+        $sql .= " ORDER BY position ASC, rowid ASC";
         $result = $this->db->query($sql);
 
-        if($result) :
-            $nb_results = $this->db->num_rows($result);
-            if($nb_results) : $i = 0;
-                while($i < $nb_results):
-                    $obj = $this->db->fetch_object($result);
-                    $soc_parclines[$obj->rowid] = $obj;
-                    $i++;
-                endwhile;
-            endif;
-     else: dol_print_error($this->db);
-     endif;
+        if(!$result) {
+            dol_print_error($this->db);
+            return $soc_parclines;
+        }
 
-     return $soc_parclines;
+        // Récupère toutes les lignes
+        $all = array();
+        $nb_results = $this->db->num_rows($result);
+        for ($i = 0; $i < $nb_results; $i++) {
+            $all[] = $this->db->fetch_object($result);
+        }
+
+        // Affichage : les éléments NON déplacés manuellement suivent l'ordre de la
+        // numérotation (champ autonumber). Les éléments déplacés manuellement
+        // (manual_position = 1) gardent leur position et sont insérés à leur place.
+        $numField = $this->getNumeroFieldKey($parc_key);
+
+        if ($numField === '') {
+            // Pas de champ de numérotation : on garde l'ordre par position (ancien comportement)
+            foreach ($all as $obj) {
+                $soc_parclines[$obj->rowid] = $obj;
+            }
+            return $soc_parclines;
+        }
+
+        foreach ($this->orderParcLines($all, $numField) as $obj) {
+            $soc_parclines[$obj->rowid] = $obj;
+        }
+
+        return $soc_parclines;
+    }
+
+    /*****************************************************************/
+    // ORDONNE UN TABLEAU D'ELEMENTS : les non-épinglés suivent la
+    // numérotation ($numField), les épinglés gardent leur position.
+    // $forceAutoRowid : traite cet élément comme non-épinglé (sert au
+    // calcul de la position naturelle pour le désépinglage).
+    /*****************************************************************/
+    public function orderParcLines(array $all, $numField, $forceAutoRowid = 0)
+    {
+        if ($numField === '') return $all;
+
+        $pinned = array();
+        $auto   = array();
+        foreach ($all as $obj) {
+            $isPinned = !empty($obj->manual_position);
+            if ($forceAutoRowid && (int) $obj->rowid === (int) $forceAutoRowid) {
+                $isPinned = false;
+            }
+            if ($isPinned) $pinned[] = $obj; else $auto[] = $obj;
+        }
+
+        // Tri naturel des éléments auto par la valeur du champ de numérotation
+        usort($auto, function ($a, $b) use ($numField) {
+            $va = isset($a->{$numField}) ? (string) $a->{$numField} : '';
+            $vb = isset($b->{$numField}) ? (string) $b->{$numField} : '';
+            $cmp = strnatcasecmp($va, $vb);
+            return $cmp !== 0 ? $cmp : ((int) $a->rowid <=> (int) $b->rowid);
+        });
+
+        // Tri des épinglés par leur position
+        usort($pinned, function ($a, $b) {
+            $cmp = ((int) $a->position) <=> ((int) $b->position);
+            return $cmp !== 0 ? $cmp : ((int) $a->rowid <=> (int) $b->rowid);
+        });
+
+        // Fusion : on insère chaque épinglé à son emplacement (position 1-based)
+        $merged = $auto;
+        foreach ($pinned as $p) {
+            $idx = ((int) $p->position) - 1;
+            if ($idx < 0) $idx = 0;
+            if ($idx > count($merged)) $idx = count($merged);
+            array_splice($merged, $idx, 0, array($p));
+        }
+
+        return $merged;
+    }
+
+    /*****************************************************************/
+    // INDIQUE SI UN ELEMENT, TRAITE COMME NON-EPINGLE, RETOMBERAIT A
+    // L'INDEX $targetIndex (1-based). Sert à désépingler automatiquement
+    // un organe redéposé à sa position naturelle (ordre de numérotation).
+    /*****************************************************************/
+    public function isAtNaturalPosition($parc_key, int $rowid, int $targetIndex)
+    {
+        $numField = $this->getNumeroFieldKey($parc_key);
+        if ($numField === '') return false;
+
+        $el = $this->fetchElement($parc_key, $rowid);
+        if (!isset($el->rowid)) return false;
+
+        $sql = "SELECT * FROM ".MAIN_DB_PREFIX.$this->table_element.'__'.$this->db->escape($parc_key);
+        $sql .= " WHERE socid = '".(int) $el->socid."'";
+        $sql .= " ORDER BY position ASC, rowid ASC";
+        $res = $this->db->query($sql);
+        if (!$res) return false;
+
+        $all = array();
+        $nb = $this->db->num_rows($res);
+        for ($i = 0; $i < $nb; $i++) {
+            $all[] = $this->db->fetch_object($res);
+        }
+
+        $ordered = $this->orderParcLines($all, $numField, $rowid);
+        $natural = 0;
+        foreach ($ordered as $idx => $obj) {
+            if ((int) $obj->rowid === (int) $rowid) { $natural = $idx + 1; break; }
+        }
+
+        return $natural === (int) $targetIndex;
+    }
+
+    /*****************************************************************/
+    // RETOURNE LA CLE DU CHAMP DE NUMEROTATION (autonumber) D'UN PARC
+    // Sert de tri par défaut. Chaîne vide si le parc n'en a pas.
+    /*****************************************************************/
+    public function getNumeroFieldKey($parc_key)
+    {
+        if (!isset($this->numeroFieldCache)) $this->numeroFieldCache = array();
+        if (array_key_exists($parc_key, $this->numeroFieldCache)) {
+            return $this->numeroFieldCache[$parc_key];
+        }
+
+        $field_key = '';
+        $sql = "SELECT f.field_key FROM ".MAIN_DB_PREFIX.$this->table_element_fields." f";
+        $sql .= " INNER JOIN ".MAIN_DB_PREFIX.$this->table_element." p ON f.parc_id = p.rowid";
+        $sql .= " WHERE p.parc_key = '".$this->db->escape($parc_key)."' AND f.type = 'autonumber'";
+        $sql .= " ORDER BY f.position ASC, f.rowid ASC";
+        $res = $this->db->query($sql);
+        if ($res && $this->db->num_rows($res) > 0) {
+            $o = $this->db->fetch_object($res);
+            $field_key = $o->field_key;
+        }
+
+        $this->numeroFieldCache[$parc_key] = $field_key;
+        return $field_key;
+    }
+
+    /*****************************************************************/
+    // MARQUE UN ELEMENT COMME DEPLACE MANUELLEMENT (épinglé) OU NON
+    /*****************************************************************/
+    public function setElementManual($parckey, int $rowid, int $val)
+    {
+        $sqlup = "UPDATE ".MAIN_DB_PREFIX.$this->table_element.'__'.$this->db->escape($parckey);
+        $sqlup .= " SET manual_position = ".((int) $val ? 1 : 0);
+        $sqlup .= " WHERE rowid = ".$rowid;
+        return $this->db->query($sqlup) ? 1 : 0;
+    }
+
+    /*****************************************************************/
+    // AJOUTE LA COLONNE manual_position AUX TABLES PAR-PARC (migration)
+    // Idempotent : ne fait rien si la colonne existe déjà.
+    /*****************************************************************/
+    public function ensureManualPositionColumn()
+    {
+        $list_parcs = $this->list_parcType();
+        foreach ($list_parcs as $parc_id => $parc) {
+            $this->ensureManualPositionColumnForParc($parc['key']);
+        }
+    }
+
+    /*****************************************************************/
+    // AJOUTE LA COLONNE manual_position A UNE TABLE PAR-PARC (migration ciblée)
+    // Idempotent. Sécurise les écritures avant que la migration globale tourne.
+    /*****************************************************************/
+    public function ensureManualPositionColumnForParc($parc_key)
+    {
+        if (empty($parc_key)) return;
+        $table = MAIN_DB_PREFIX.$this->table_element.'__'.$this->db->escape($parc_key);
+        $rescol = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'manual_position'");
+        if (!$rescol || $this->db->num_rows($rescol) > 0) return; // colonne déjà présente
+
+        if (!$this->db->DDLAddField($table, 'manual_position', array('type'=>'BOOLEAN','null'=>'NOT NULL','extra'=>'DEFAULT 0'))) {
+            return;
+        }
+
+        // Migration unique (à la création de la colonne) : on préserve les
+        // arrangements manuels existants. Pour chaque tiers, si l'ordre enregistré
+        // (position) diffère de l'ordre de création (rowid), le parc a été arrangé
+        // manuellement -> on épingle tous ses éléments pour conserver l'ordre.
+        // Sinon (ordre = ordre de création), il n'a jamais été déplacé -> on le
+        // laisse suivre la numérotation (manual_position = 0 par défaut).
+        $res = $this->db->query("SELECT rowid, socid FROM ".$table." ORDER BY socid ASC, position ASC, rowid ASC");
+        if (!$res) return;
+
+        $bySoc = array();
+        while ($o = $this->db->fetch_object($res)) {
+            $bySoc[(int) $o->socid][] = (int) $o->rowid;
+        }
+        foreach ($bySoc as $socid => $rowids) {
+            $sorted = $rowids;
+            sort($sorted, SORT_NUMERIC);
+            if ($rowids !== $sorted) {
+                $this->db->query("UPDATE ".$table." SET manual_position = 1 WHERE socid = ".(int) $socid);
+            }
+        }
     }
 
     public function getSocParcCount($socid, $parc_key, $isverif = false)
@@ -570,7 +755,8 @@ class GestionParc
 
         $this->db->begin();
 
-        $sql = "INSERT INTO ".MAIN_DB_PREFIX.$this->table_element.'__'.$this->db->escape($parckey)." (socid, author, position";
+        // Un clone est considéré comme placé manuellement (épinglé) pour conserver son emplacement
+        $sql = "INSERT INTO ".MAIN_DB_PREFIX.$this->table_element.'__'.$this->db->escape($parckey)." (socid, author, position, manual_position";
         foreach ($this->fields as $parcfield) {
             $sql .= ", ".$parcfield->field_key;
         }
@@ -578,6 +764,7 @@ class GestionParc
         $sql .= (int) $element->socid;
         $sql .= ", ".(int) $user->id;
         $sql .= ", ".(int) $position;
+        $sql .= ", 1";
         foreach ($this->fields as $parcfield) {
             if ($parcfield->type === 'autonumber') {
                 $new_val = $parcfield->getNextAutoNumber((int) $element->socid, $parckey, $parcfield->field_key);
@@ -1519,11 +1706,331 @@ class GestionParcVerif
     public $fichinter_id;
     public $is_close;
     public $files_list;
+    public $commercial;
+    public $intervenant;
     public $db;
 
     public function __construct($db)
     {
         $this->db = $db;
+    }
+
+    /*****************************************************************/
+    // AJOUTE LA COLONNE report_snapshot A LA TABLE DES VERIFS (migration)
+    // Stocke l'instantané des données d'organes à la clôture. Idempotent.
+    /*****************************************************************/
+    public function ensureVerifSnapshotColumn()
+    {
+        $table = MAIN_DB_PREFIX.$this->table_element;
+        $rescol = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'report_snapshot'");
+        if ($rescol && $this->db->num_rows($rescol) == 0) {
+            $this->db->query("ALTER TABLE ".$table." ADD report_snapshot MEDIUMTEXT NULL DEFAULT NULL");
+        }
+        // Sauvegarde des valeurs réinitialisées à l'ouverture (force_default_on_verif),
+        // pour pouvoir les restaurer si la vérif est annulée.
+        $rescol2 = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'reset_backup'");
+        if ($rescol2 && $this->db->num_rows($rescol2) == 0) {
+            $this->db->query("ALTER TABLE ".$table." ADD reset_backup MEDIUMTEXT NULL DEFAULT NULL");
+        }
+    }
+
+    /*****************************************************************/
+    // ENREGISTRE L'INSTANTANE DES DONNEES D'UNE VERIF (à la clôture)
+    /*****************************************************************/
+    public function storeVerifSnapshot($verif_rowid, $report_data)
+    {
+        $this->ensureVerifSnapshotColumn();
+        $json = json_encode($report_data);
+        if ($json === false) return 0;
+        $sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element;
+        $sql .= " SET report_snapshot = '".$this->db->escape($json)."'";
+        $sql .= " WHERE rowid = ".(int) $verif_rowid;
+        return $this->db->query($sql) ? 1 : 0;
+    }
+
+    /*****************************************************************/
+    // RECUPERE L'INSTANTANE D'UNE VERIF A PARTIR DE L'INTERVENTION
+    // Retourne le tableau report_data figé à la clôture, ou null.
+    /*****************************************************************/
+    public function getVerifSnapshotByFichinter($fichinter_id)
+    {
+        $table = MAIN_DB_PREFIX.$this->table_element;
+        $rescol = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'report_snapshot'");
+        if (!$rescol || $this->db->num_rows($rescol) == 0) return null; // colonne absente (anciennes installs)
+
+        $sql = "SELECT report_snapshot FROM ".$table;
+        $sql .= " WHERE fichinter_id = ".(int) $fichinter_id." AND is_close = 1";
+        $sql .= " ORDER BY rowid DESC LIMIT 1";
+        $res = $this->db->query($sql);
+        if (!$res || !$this->db->num_rows($res)) return null;
+
+        $o = $this->db->fetch_object($res);
+        if (empty($o->report_snapshot)) return null;
+
+        $data = json_decode($o->report_snapshot, true);
+        return is_array($data) ? $data : null;
+    }
+
+    /*****************************************************************/
+    // BACKPORT DES SNAPSHOTS A PARTIR DES RAPPORTS XLSX HISTORIQUES
+    // Reconstruit report_snapshot (en-tête + organes) pour les vérifs
+    // clôturées qui n'en ont pas, à partir des fichiers rapport_*.xlsx
+    // présents dans le répertoire documents de chaque intervention.
+    //   $commit = false : dry-run (n'écrit rien) ; true : écrit en base
+    //   $force  = true  : réécrit même si un snapshot existe déjà
+    //   $maxItems       : limite (0 = tout)
+    // Retourne un tableau de statistiques.
+    /*****************************************************************/
+    public function backportSnapshots($commit = false, $force = false, $maxItems = 0)
+    {
+        global $conf;
+
+        @set_time_limit(0);
+        $stats = array('total'=>0,'skipped_has'=>0,'no_xlsx'=>0,'parsed'=>0,'written'=>0,'suspect_mtime'=>0,'parse_empty'=>0);
+
+        if ($commit) $this->ensureVerifSnapshotColumn();
+
+        // La colonne doit exister pour lire/écrire
+        $table = MAIN_DB_PREFIX.$this->table_element;
+        $rescol = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'report_snapshot'");
+        $has_col = ($rescol && $this->db->num_rows($rescol) > 0);
+
+        $base_dir = !empty($conf->ficheinter->dir_output) ? $conf->ficheinter->dir_output : (!empty($conf->fichinter->dir_output) ? $conf->fichinter->dir_output : DOL_DATA_ROOT.'/fichinter');
+
+        $snapcol = $has_col ? "v.report_snapshot" : "NULL AS report_snapshot";
+        $sql = "SELECT v.rowid, v.fichinter_id, f.ref, v.date_close, ".$snapcol;
+        $sql .= " FROM ".$table." v";
+        $sql .= " JOIN ".MAIN_DB_PREFIX."fichinter f ON f.rowid = v.fichinter_id";
+        $sql .= " WHERE v.is_close = 1";
+        $sql .= " ORDER BY v.date_close DESC";
+        $res = $this->db->query($sql);
+        if (!$res) return $stats;
+
+        while ($row = $this->db->fetch_object($res)) {
+            if ($maxItems && $stats['total'] >= $maxItems) break;
+            $stats['total']++;
+
+            if (!$force && $has_col && $row->report_snapshot !== null && $row->report_snapshot !== '') {
+                $stats['skipped_has']++;
+                continue;
+            }
+
+            $closeTs = !empty($row->date_close) ? strtotime($row->date_close) : 0;
+            $closeYear = !empty($row->date_close) ? (int) substr($row->date_close, 0, 4) : 0;
+
+            $dir = $base_dir.'/'.dol_sanitizeFileName($row->ref);
+            list($file, $kind) = self::pickHistoryXlsx($dir, $row->ref, $closeYear);
+            if (!$file) { $stats['no_xlsx']++; continue; }
+
+            if ($kind === 'legacy' && $closeTs) {
+                $mtime = @filemtime($file);
+                if ($mtime && $mtime > $closeTs + 86400 * 7) $stats['suspect_mtime']++;
+            }
+
+            try {
+                $report = self::parseXlsxReport($file);
+            } catch (Exception $e) {
+                $stats['parse_empty']++;
+                continue;
+            }
+            if (empty($report['sections'])) { $stats['parse_empty']++; continue; }
+            $stats['parsed']++;
+
+            if ($commit && $has_col) {
+                $json = json_encode($report, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
+                if ($json !== false) {
+                    $u = $this->db->query("UPDATE ".$table." SET report_snapshot = '".$this->db->escape($json)."' WHERE rowid = ".(int) $row->rowid);
+                    if ($u) $stats['written']++;
+                }
+            }
+        }
+
+        return $stats;
+    }
+
+    /*****************************************************************/
+    // CHOISIT LE MEILLEUR XLSX HISTORIQUE POUR UNE INTERVENTION
+    /*****************************************************************/
+    public static function pickHistoryXlsx($dir, $ref, $closeYear)
+    {
+        $byref = $dir.'/rapport_'.$ref.'.xlsx';
+        if (is_file($byref)) return array($byref, 'ref');
+        if ($closeYear) {
+            $byyear = $dir.'/rapport_verification_'.$closeYear.'.xlsx';
+            if (is_file($byyear)) return array($byyear, 'year');
+        }
+        $legacy = $dir.'/rapport_verification.xlsx';
+        if (is_file($legacy)) return array($legacy, 'legacy');
+        return array('', '');
+    }
+
+    /*****************************************************************/
+    // PARSE UN RAPPORT XLSX DU MODULE EN STRUCTURE report_data
+    // { max_cols, header:{...}, sections:[{label,fields,lines,stats}] }
+    /*****************************************************************/
+    public static function parseXlsxReport($file)
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($file) !== true) throw new Exception('zip open');
+
+        // shared strings
+        $ss = array();
+        if (($s = $zip->getFromName('xl/sharedStrings.xml')) !== false) {
+            $x = @simplexml_load_string($s);
+            if ($x) foreach ($x->si as $si) {
+                if (isset($si->t) && count($si->r) == 0) $ss[] = (string) $si->t;
+                else { $t = ''; foreach ($si->r as $r) $t .= (string) $r->t; $ss[] = $t; }
+            }
+        }
+
+        // workbook : nom de feuille -> rId ; rels : rId -> fichier worksheet
+        $wb = @simplexml_load_string($zip->getFromName('xl/workbook.xml'));
+        $rels = @simplexml_load_string($zip->getFromName('xl/_rels/workbook.xml.rels'));
+        $relMap = array();
+        if ($rels) foreach ($rels->Relationship as $r) $relMap[(string) $r['Id']] = (string) $r['Target'];
+        $sheets = array();
+        if ($wb) foreach ($wb->sheets->sheet as $sh) {
+            $name = (string) $sh['name'];
+            $rid = '';
+            foreach ($sh->attributes('http://schemas.openxmlformats.org/officeDocument/2006/relationships') as $k => $v) { if ($k == 'id') $rid = (string) $v; }
+            $target = isset($relMap[$rid]) ? $relMap[$rid] : '';
+            if ($target && strpos($target, '/') !== 0 && strpos($target, 'xl/') !== 0) $target = 'xl/'.$target;
+            $sheets[] = array('name' => $name, 'path' => $target);
+        }
+
+        $report = array('max_cols' => 4, 'header' => array(), 'sections' => array());
+        $headerCaptured = false;
+
+        foreach ($sheets as $sheet) {
+            if (self::snapNorm($sheet['name']) === self::snapNorm('RAPPORT COMPLET')) continue;
+            $xml = $zip->getFromName($sheet['path']);
+            if ($xml === false) continue;
+            $grid = self::sheetGrid($xml, $ss);
+            if (empty($grid)) continue;
+
+            // ligne d'en-tête colonnes = 1re ligne où col A et col B sont remplies
+            $headerRow = 0; $maxRow = max(array_keys($grid));
+            for ($r = 1; $r <= $maxRow; $r++) {
+                $a = isset($grid[$r][0]) ? trim((string) $grid[$r][0]) : '';
+                $b = isset($grid[$r][1]) ? trim((string) $grid[$r][1]) : '';
+                if ($a !== '' && $b !== '') { $headerRow = $r; break; }
+            }
+            if (!$headerRow) continue;
+
+            // bloc en-tête (avant headerRow) : libellé col C, valeur col D ou E
+            $h = array(); $parclabel = '';
+            for ($r = 1; $r < $headerRow; $r++) {
+                $label = isset($grid[$r][2]) ? self::snapNorm($grid[$r][2]) : '';
+                if ($label === '') continue;
+                $val = '';
+                foreach (array(3, 4) as $cc) { if (isset($grid[$r][$cc]) && trim((string) $grid[$r][$cc]) !== '') { $val = trim((string) $grid[$r][$cc]); break; } }
+                if ($val === '') continue;
+                // Certains rapports anciens ont été générés sans la langue chargée :
+                // le libellé est alors la clé brute (gp_advexp_user, gp_advexp_commercial, gp_advexp_parctype).
+                if (strpos($label, 'technicien') !== false || strpos($label, 'gp_advexp_user') !== false) $h['technicien'] = $val;
+                elseif (strpos($label, 'commercial') !== false) $h['commercial'] = $val;
+                elseif ($label === 'client') $h['client'] = $val;
+                elseif (strpos($label, 'adresse') !== false) $h['address'] = $val;
+                elseif (strpos($label, 'tel') === 0 || strpos($label, 'telephone') !== false) $h['phone'] = $val;
+                elseif (strpos($label, 'code client') !== false) $h['code_client'] = $val;
+                elseif (strpos($label, "type d'organe") !== false || strpos($label, 'gp_advexp_parctype') !== false) $parclabel = $val;
+            }
+            if (!$headerCaptured && $h) { $report['header'] = $h; $headerCaptured = true; }
+
+            // libellés de colonnes (headerRow), de A jusqu'à la 1re colonne vide
+            $colLabels = array(); $c = 0;
+            while (isset($grid[$headerRow][$c]) && trim((string) $grid[$headerRow][$c]) !== '') { $colLabels[] = trim((string) $grid[$headerRow][$c]); $c++; }
+            $ncol = count($colLabels);
+            if ($ncol < 1) continue;
+
+            // lignes de données
+            $lines = array(); $verified = null; $total_from_summary = null;
+            for ($r = $headerRow + 1; $r <= $maxRow; $r++) {
+                $rowAllText = '';
+                for ($cc = 0; $cc < $ncol; $cc++) $rowAllText .= ' '.(isset($grid[$r][$cc]) ? (string) $grid[$r][$cc] : '');
+                if (preg_match('/verifie/', self::snapNorm($rowAllText)) && preg_match('/(\d+)\s*\/\s*(\d+)/', $rowAllText, $mm)) {
+                    $verified = (int) $mm[1]; $total_from_summary = (int) $mm[2]; break;
+                }
+                $vals = array(); $nonEmpty = false;
+                for ($cc = 0; $cc < $ncol; $cc++) { $v = isset($grid[$r][$cc]) ? (string) $grid[$r][$cc] : ''; $vals[] = $v; if (trim($v) !== '') $nonEmpty = true; }
+                if (!$nonEmpty) continue;
+                // L'ancien format pagine dans la même feuille : il répète le bloc
+                // d'en-tête + la ligne de colonnes avant chaque sous-tableau. On
+                // ignore ces lignes pour ne garder que les vraies données.
+                if (self::isHeaderNoise($vals, $colLabels)) continue;
+                $lines[] = $vals;
+            }
+            if (empty($lines)) continue;
+
+            $fields = array();
+            foreach ($colLabels as $i => $lab) $fields['c'.$i] = array('label' => $lab, 'type' => '', 'pos' => $i, 'align' => '');
+
+            $total = count($lines);
+            $report['sections'][] = array(
+                'label'  => $parclabel !== '' ? $parclabel : $sheet['name'],
+                'fields' => $fields,
+                'lines'  => $lines,
+                'stats'  => array('total' => $total_from_summary !== null ? $total_from_summary : $total, 'verified' => $verified !== null ? $verified : $total),
+            );
+            if ($ncol > $report['max_cols']) $report['max_cols'] = $ncol;
+        }
+
+        $zip->close();
+        return $report;
+    }
+
+    /** Lit une feuille XLSX (XML) en grille [rowNum][colIdx0] = valeur résolue. */
+    protected static function sheetGrid($xml, $ss)
+    {
+        $x = @simplexml_load_string($xml);
+        $grid = array();
+        if (!$x || !isset($x->sheetData)) return $grid;
+        foreach ($x->sheetData->row as $row) {
+            $rn = (int) $row['r'];
+            foreach ($row->c as $c) {
+                $ref = (string) $c['r'];
+                $ci = 0;
+                if (preg_match('/^([A-Z]+)(\d+)$/', $ref, $m)) { $cc = $m[1]; for ($k = 0; $k < strlen($cc); $k++) $ci = $ci * 26 + (ord($cc[$k]) - 64); $ci--; }
+                $t = (string) $c['t'];
+                if ($t === 'inlineStr') { $v = isset($c->is->t) ? (string) $c->is->t : ''; }
+                else { $v = isset($c->v) ? (string) $c->v : ''; if ($t === 's') $v = isset($ss[(int) $v]) ? $ss[(int) $v] : ''; }
+                $grid[$rn][$ci] = $v;
+            }
+        }
+        return $grid;
+    }
+
+    /** Normalise une chaîne (minuscule, sans accents) pour comparaison de libellés. */
+    protected static function snapNorm($s)
+    {
+        $s = mb_strtolower(trim((string) $s));
+        return strtr($s, array('é'=>'e','è'=>'e','ê'=>'e','à'=>'a','â'=>'a','î'=>'i','ï'=>'i','ô'=>'o','û'=>'u','ç'=>'c','’'=>"'"));
+    }
+
+    /**
+     * Détecte une ligne "parasite" issue d'un bloc d'en-tête répété dans la feuille
+     * (ancien format paginé) : ligne d'en-tête de colonnes répétée, ligne de titre,
+     * ou ligne d'info (colonne B vide + colonne C = libellé d'en-tête connu).
+     */
+    protected static function isHeaderNoise($row, $colLabels)
+    {
+        // Ligne d'en-tête de colonnes répétée
+        if ($row === $colLabels) return true;
+
+        $a = isset($row[0]) ? self::snapNorm($row[0]) : '';
+        $b = isset($row[1]) ? trim((string) $row[1]) : '';
+        $c = isset($row[2]) ? self::snapNorm($row[2]) : '';
+
+        // Ligne de titre du rapport
+        if (strpos($a, 'rapport de verif') !== false || strpos($a, 'gp_advexp_title') !== false) return true;
+
+        // Ligne d'info d'en-tête : colonne Produit (B) vide + colonne C = libellé connu
+        if ($b === '' && $c !== '') {
+            foreach (array('date de passage', 'technicien', 'commercial', 'client', 'adresse', 'tel', 'code client', "type d'organe", 'gp_advexp') as $kw) {
+                if (strpos($c, $kw) !== false) return true;
+            }
+        }
+        return false;
     }
 
     /*****************************************************************/
@@ -1553,6 +2060,8 @@ class GestionParcVerif
          $this->fichinter_id = $item->fichinter_id;
          $this->is_close = $item->is_close;
          $this->files_list = !empty($item->files_list) ? json_decode($item->files_list) : array();
+         $this->commercial = isset($item->commercial) ? intval($item->commercial) : 0;
+         $this->intervenant = isset($item->intervenant) ? intval($item->intervenant) : 0;
 
          return $this->rowid;
      endif;
@@ -1582,6 +2091,7 @@ class GestionParcVerif
         $list_parctypes = $gestionparc->list_parcType();
 
         $nb_lines = 0;
+        $reset_backup = array(); // valeurs d'origine des champs réinitialisés (pour restauration si annulation)
 
         foreach($list_parctypes as $parctype_key => $parctype_infos):
             $parc_lines = $gestionparc->getSocParcContent($socid, $parctype_infos['key']);
@@ -1591,9 +2101,16 @@ class GestionParcVerif
                 $this->setLineCheck($socid, $parctype_infos['key'], $parcline->rowid, 0);
 
                 // Reset fields with force_default_on_verif to their default value
+                // (y compris une valeur par défaut vide : le champ est alors vidé,
+                //  ex. "Observations" remis à zéro à chaque nouvelle vérification)
                 $fields = $gestionparc->list_parcFields($parctype_key);
                 foreach($fields as $field):
-                    if($field->force_default_on_verif && !empty($field->default_value)):
+                    if($field->force_default_on_verif):
+                        // Sauvegarde de la valeur d'origine avant écrasement (restauration si annulation)
+                        $old_value = isset($parcline->{$field->field_key}) ? $parcline->{$field->field_key} : '';
+                        if ((string) $old_value !== (string) $field->default_value) {
+                            $reset_backup[$parctype_infos['key']][$parcline->rowid][$field->field_key] = $old_value;
+                        }
                         $sql_reset = "UPDATE ".MAIN_DB_PREFIX.$this->parent_table_element."__".$parctype_infos['key'];
                         $sql_reset .= " SET `".$field->field_key."` = '".$this->db->escape($field->default_value)."'";
                         $sql_reset .= " WHERE rowid = '".$parcline->rowid."' AND socid = '".$socid."'";
@@ -1604,17 +2121,396 @@ class GestionParcVerif
 
         endforeach;
 
+        // Commercial / intervenant repris de la précédente intervention (sinon valeurs par défaut)
+        list($def_commercial, $def_intervenant) = $this->getDefaultVerifUsers($socid);
+
         $sql = "INSERT INTO ".MAIN_DB_PREFIX.$this->table_element;
-        $sql.= " (socid,author,nb_total) VALUES ('".$socid."', '".$user->id."','".$nb_lines."')";
+        $sql.= " (socid,author,nb_total,commercial,intervenant) VALUES ('".$socid."', '".$user->id."','".$nb_lines."','".(int) $def_commercial."','".(int) $def_intervenant."')";
         $result = $this->db->query($sql);
 
         if($result) :
             $this->rowid = $this->db->last_insert_id(MAIN_DB_PREFIX.$this->table_element);
             $this->socid = $socid;
             $this->author = $user->id;
+            $this->commercial = (int) $def_commercial;
+            $this->intervenant = (int) $def_intervenant;
+
+            // Mémorise les valeurs d'origine réinitialisées pour pouvoir les restaurer si la vérif est annulée
+            if (!empty($reset_backup)) {
+                $this->ensureVerifSnapshotColumn();
+                $json = json_encode($reset_backup, JSON_UNESCAPED_UNICODE);
+                if ($json !== false) {
+                    $this->db->query("UPDATE ".MAIN_DB_PREFIX.$this->table_element." SET reset_backup = '".$this->db->escape($json)."' WHERE rowid = ".(int) $this->rowid);
+                }
+            }
+
             return $this->rowid;
      else: return false;
      endif;
+    }
+
+    /*****************************************************************/
+    // VALEURS PAR DEFAUT COMMERCIAL / INTERVENANT POUR UNE NOUVELLE VERIF
+    // 1. Reprise depuis la précédente intervention clôturée (commercial ET
+    //    intervenant) - cohérent avec ce qu'affiche l'onglet avant la verif,
+    //    pour ne pas écraser le choix existant.
+    // 2. Repli si vide : commercial = commercial du tiers, intervenant =
+    //    utilisateur courant.
+    /*****************************************************************/
+    public function getDefaultVerifUsers($socid)
+    {
+        global $user;
+
+        include_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
+        include_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
+
+        $commercial = 0;
+        $intervenant = 0;
+
+        // 1. Reprise depuis la précédente intervention clôturée (commercial + intervenant)
+        $last_fichinter_id = $this->getLastVerif($socid);
+        if ($last_fichinter_id) {
+            $prev = new Fichinter($this->db);
+            if ($prev->fetch($last_fichinter_id) > 0) {
+                $prev->fetch_optionals();
+                $commercial  = !empty($prev->array_options['options_gestionparc_commercial'])  ? (int) $prev->array_options['options_gestionparc_commercial']  : 0;
+                $intervenant = !empty($prev->array_options['options_gestionparc_intervenant']) ? (int) $prev->array_options['options_gestionparc_intervenant'] : 0;
+            }
+        }
+
+        // 2a. Repli commercial : commercial actuel du tiers
+        if (empty($commercial)) {
+            $soc = new Societe($this->db);
+            if ($soc->fetch($socid) > 0) {
+                $reps = $soc->getSalesRepresentatives($user);
+                if (!empty($reps)) {
+                    $commercial = (int) $reps[0]['id'];
+                }
+            }
+        }
+
+        // 2b. Repli intervenant : utilisateur courant
+        if (empty($intervenant)) {
+            $intervenant = (int) $user->id;
+        }
+
+        return array($commercial, $intervenant);
+    }
+
+    /*****************************************************************/
+    // METTRE A JOUR COMMERCIAL / INTERVENANT D'UNE VERIF EN COURS
+    /*****************************************************************/
+    public function updateVerifUsers($rowid, $commercial, $intervenant)
+    {
+        $sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element;
+        $sql.= " SET commercial = '".(int) $commercial."', intervenant = '".(int) $intervenant."'";
+        $sql.= " WHERE rowid = '".(int) $rowid."'";
+
+        if ($this->db->query($sql)) {
+            $this->commercial = (int) $commercial;
+            $this->intervenant = (int) $intervenant;
+            return 1;
+        }
+        return -1;
+    }
+
+    /*****************************************************************/
+    // METTRE A JOUR UN SEUL CHAMP (commercial | intervenant) D'UNE VERIF
+    /*****************************************************************/
+    public function updateVerifUserField($rowid, $field, $value)
+    {
+        if (!in_array($field, array('commercial', 'intervenant'))) {
+            return -1;
+        }
+
+        $sql = "UPDATE ".MAIN_DB_PREFIX.$this->table_element;
+        $sql.= " SET ".$field." = '".(int) $value."'";
+        $sql.= " WHERE rowid = '".(int) $rowid."'";
+
+        if ($this->db->query($sql)) {
+            $this->{$field} = (int) $value;
+            return 1;
+        }
+        return -1;
+    }
+
+    /*****************************************************************/
+    // RECOPIE COMMERCIAL / INTERVENANT DE LA CAMPAGNE VERS LES EXTRAFIELDS
+    // DE LA FICHE D'INTERVENTION (appelé à la clôture). Repli intervenant
+    // sur le valideur courant si la campagne n'en porte pas.
+    /*****************************************************************/
+    public function writeInterventionUsers($intervention, $verif_rowid)
+    {
+        global $user;
+
+        $commercial = 0; $intervenant = 0;
+        $resu = $this->db->query("SELECT commercial, intervenant FROM ".MAIN_DB_PREFIX.$this->table_element." WHERE rowid = ".(int) $verif_rowid);
+        if ($resu && ($o = $this->db->fetch_object($resu))) {
+            $commercial  = (int) $o->commercial;
+            $intervenant = (int) $o->intervenant;
+        }
+        if (empty($intervenant)) {
+            $intervenant = (int) $user->id;
+        }
+
+        $intervention->array_options['options_gestionparc_commercial']  = $commercial  ? $commercial  : '';
+        $intervention->array_options['options_gestionparc_intervenant'] = $intervenant ? $intervenant : '';
+        $intervention->updateExtraField('gestionparc_commercial');
+        $intervention->updateExtraField('gestionparc_intervenant');
+    }
+
+    /*****************************************************************/
+    // RECOPIE LES CHAMPS PERSONNALISES DU TIERS VERS LES EXTRAFIELDS
+    // DE LA FICHE D'INTERVENTION (snapshot à la clôture/validation).
+    /*****************************************************************/
+    public function writeInterventionCustomSocFields($intervention, $socid)
+    {
+        require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
+
+        $soc = new Societe($this->db);
+        if ($soc->fetch($socid) <= 0) return -1;
+        $soc->fetch_optionals();
+
+        foreach (array_keys(self::getCustomSocFields()) as $code) {
+            $opt_key = 'options_'.$code;
+            $value = isset($soc->array_options[$opt_key]) ? $soc->array_options[$opt_key] : '';
+            $intervention->array_options[$opt_key] = $value;
+            $intervention->updateExtraField($code);
+        }
+        return 1;
+    }
+
+    /*****************************************************************/
+    // BACKFILL DES INTERVENTIONS DE VERIF EXISTANTES
+    // - intervenant : = valideur (fk_user_valid)
+    // - commercial  : = commercial actuel du tiers (1er de societe_commerciaux)
+    // Idempotent : ne renseigne que les valeurs vides.
+    /*****************************************************************/
+    public function backfillInterventionUsers()
+    {
+        // Intervenant <- valideur de l'intervention
+        $sql = "UPDATE ".MAIN_DB_PREFIX."fichinter_extrafields as ef";
+        $sql.= " INNER JOIN ".MAIN_DB_PREFIX."fichinter as f ON f.rowid = ef.fk_object";
+        $sql.= " SET ef.gestionparc_intervenant = f.fk_user_valid";
+        $sql.= " WHERE (ef.gestionparc_intervenant IS NULL OR ef.gestionparc_intervenant = '' OR ef.gestionparc_intervenant = '0')";
+        $sql.= " AND ef.gestionparc_isverif IS NOT NULL AND ef.gestionparc_isverif > 0";
+        $sql.= " AND f.fk_user_valid > 0";
+        $this->db->query($sql);
+
+        // Commercial <- commercial actuel du tiers (boucle PHP : UPDATE mono-table par rowid, fiable)
+        $sql = "SELECT ef.rowid as ef_rowid, f.fk_soc";
+        $sql.= " FROM ".MAIN_DB_PREFIX."fichinter_extrafields as ef";
+        $sql.= " INNER JOIN ".MAIN_DB_PREFIX."fichinter as f ON f.rowid = ef.fk_object";
+        $sql.= " WHERE (ef.gestionparc_commercial IS NULL OR ef.gestionparc_commercial = '' OR ef.gestionparc_commercial = '0')";
+        $sql.= " AND ef.gestionparc_isverif IS NOT NULL AND ef.gestionparc_isverif > 0";
+
+        $resql = $this->db->query($sql);
+        if ($resql) {
+            $cache_com = array();
+            while ($obj = $this->db->fetch_object($resql)) {
+                $soc = (int) $obj->fk_soc;
+                if (!isset($cache_com[$soc])) {
+                    $cache_com[$soc] = 0;
+                    $r = $this->db->query("SELECT MIN(fk_user) as fk_user FROM ".MAIN_DB_PREFIX."societe_commerciaux WHERE fk_soc = ".$soc);
+                    if ($r && ($o = $this->db->fetch_object($r)) && $o->fk_user > 0) {
+                        $cache_com[$soc] = (int) $o->fk_user;
+                    }
+                }
+                if ($cache_com[$soc] > 0) {
+                    $this->db->query("UPDATE ".MAIN_DB_PREFIX."fichinter_extrafields SET gestionparc_commercial = '".$cache_com[$soc]."' WHERE rowid = ".(int) $obj->ef_rowid);
+                }
+            }
+        }
+
+        return 1;
+    }
+
+    /*****************************************************************/
+    // CREE / MIGRE LES EXTRAFIELDS FICHINTER (commercial, intervenant)
+    // + LANCE LE BACKFILL. Type 'link' vers user. Idempotent.
+    /*****************************************************************/
+    public function ensureInterventionExtrafields()
+    {
+        require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+
+        $extrafields = new ExtraFields($this->db);
+        $extras_fichinter = $extrafields->fetch_name_optionals_label('fichinter');
+
+        $param_user = array('options' => array('User:user/class/user.class.php:0' => null));
+        $defs = array(
+            'gestionparc_commercial'  => array('gp_extrafieldFichInter_commercial', '101'),
+            'gestionparc_intervenant' => array('gp_extrafieldFichInter_intervenant', '102'),
+        );
+
+        // entity laissé vide : create_label/update_label utilisent alors $conf->entity en interne
+        // (évite tout risque d'insérer une valeur non numérique dans la colonne entity).
+        foreach ($defs as $code => $def) {
+            $curtype = isset($extrafields->attributes['fichinter']['type'][$code]) ? $extrafields->attributes['fichinter']['type'][$code] : '';
+            if (!array_key_exists($code, $extras_fichinter)) {
+                $extrafields->addExtraField($code, $def[0], 'link', $def[1], '', 'fichinter', 0, 0, '', $param_user, 1, '', '1', '', '', '', 'gestionparc@gestionparc');
+            } elseif ($curtype !== 'link') {
+                // Migration ancienne définition (sellist) -> link
+                $extrafields->update($code, $def[0], 'link', 0, 'fichinter', 0, 0, $def[1], $param_user, 1, '', '1', '', '', '', '', 'gestionparc@gestionparc');
+            }
+        }
+
+        // Champs personnalisés : snapshot sur la fiche d'intervention (visible/éditable sur la card)
+        foreach (self::getCustomSocFields() as $code => $def) {
+            if (!array_key_exists($code, $extras_fichinter)) {
+                $param = array('options' => $def['options']);
+                $extrafields->addExtraField($code, $def['label'], 'checkbox', $def['pos_inter'], '', 'fichinter', 0, 0, '', $param, 1, '', '1', '', '', '', 'gestionparc@gestionparc');
+            }
+        }
+
+        // Renseigne l'intervenant (= valideur) des interventions de vérification existantes
+        $this->backfillInterventionUsers();
+    }
+
+    /*****************************************************************/
+    // CONFIG DES CHAMPS PERSONNALISES TIERS (cases à cocher).
+    // Chaque champ : extrafield 'checkbox' sur le tiers (saisi dans
+    // l'onglet GestionParc) + snapshot sur l'intervention à la clôture,
+    // affiché en bas du header des exports. Pour en ajouter un, il suffit
+    // d'ajouter une entrée ici.
+    //   label    : clé de langue du libellé du champ
+    //   pos_soc  : position de l'extrafield societe
+    //   pos_inter: position de l'extrafield fichinter
+    //   required : si true, au moins une case doit être cochée pour clôturer
+    //   options  : cle => libellé des cases à cocher
+    /*****************************************************************/
+    public static function getCustomSocFields()
+    {
+        return array(
+            'gestionparc_referentiel' => array(
+                'label'    => 'gp_referentiel_conformite',
+                'pos_soc'  => 100,
+                'pos_inter'=> 103,
+                'required' => true,
+                'options'  => array(
+                    'apsadr4'       => 'APSAD R4',
+                    'codedutravail' => 'Code du Travail',
+                ),
+            ),
+            'gestionparc_typedeplan' => array(
+                'label'    => 'gp_typedeplan',
+                'pos_soc'  => 101,
+                'pos_inter'=> 104,
+                'required' => true,
+                'options'  => array(
+                    'plansecurite'     => 'Plan de sécurité',
+                    'planintervention' => "Plan d'intervention",
+                    'planevacuation'   => "Plan d'évacuation",
+                    'sans'             => 'Sans',
+                ),
+            ),
+        );
+    }
+
+    /*****************************************************************/
+    // CREE LES EXTRAFIELDS SOCIETE (champs personnalisés cases à cocher).
+    // Affichés/édités uniquement depuis l'onglet GestionParc (list = 0).
+    // Idempotent.
+    /*****************************************************************/
+    public function ensureSocieteExtrafields()
+    {
+        require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+
+        $extrafields = new ExtraFields($this->db);
+        $extras_societe = $extrafields->fetch_name_optionals_label('societe');
+
+        // entity laissé vide : create_label utilise alors $conf->entity en interne.
+        foreach (self::getCustomSocFields() as $code => $def) {
+            if (!array_key_exists($code, $extras_societe)) {
+                $param = array('options' => $def['options']);
+                $extrafields->addExtraField($code, $def['label'], 'checkbox', $def['pos_soc'], '', 'societe', 0, 0, '', $param, 1, '', '0', '', '', '', 'gestionparc@gestionparc');
+            }
+        }
+    }
+
+    /*****************************************************************/
+    // RESOLUTION D'UN CHAMP PERSONNALISE EN TEXTE (pour exports)
+    // Lit en priorité le snapshot de l'intervention ; repli sur le tiers
+    // (anciennes interventions). Retourne les libelles separes par ", ".
+    /*****************************************************************/
+    public static function resolveCustomSocField($db, $fieldkey, $intervention, $customer = null)
+    {
+        $fields = self::getCustomSocFields();
+        if (!isset($fields[$fieldkey])) return '';
+        $opt_key = 'options_'.$fieldkey;
+
+        $raw = '';
+
+        // 1. Snapshot porté par l'intervention
+        if (is_object($intervention)) {
+            if (empty($intervention->array_options)) $intervention->fetch_optionals();
+            if (!empty($intervention->array_options[$opt_key])) {
+                $raw = $intervention->array_options[$opt_key];
+            }
+        }
+
+        // 2. Repli sur le tiers si l'intervention ne porte pas la valeur
+        if ($raw === '' && is_object($customer)) {
+            if (empty($customer->array_options)) $customer->fetch_optionals();
+            $raw = isset($customer->array_options[$opt_key]) ? $customer->array_options[$opt_key] : '';
+        }
+
+        if ($raw === '' || $raw === null) return '';
+
+        $options = $fields[$fieldkey]['options'];
+        $labels = array();
+        foreach (explode(',', $raw) as $key) {
+            $key = trim($key);
+            if ($key === '') continue;
+            $labels[] = isset($options[$key]) ? $options[$key] : $key;
+        }
+
+        return implode(', ', $labels);
+    }
+
+    /*****************************************************************/
+    // RESOLUTION DES NOMS TECHNICIEN / COMMERCIAL POUR LES EXPORTS
+    // Lit les extrafields de l'intervention ; repli sur l'ancien
+    // comportement (utilisateur courant / commerciaux du tiers) si vide.
+    /*****************************************************************/
+    public static function resolveExportUsers($db, $intervention, $customer)
+    {
+        global $user;
+
+        require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
+
+        if (empty($intervention->array_options)) {
+            $intervention->fetch_optionals();
+        }
+
+        $intervenant_id = !empty($intervention->array_options['options_gestionparc_intervenant']) ? (int) $intervention->array_options['options_gestionparc_intervenant'] : 0;
+        $commercial_id  = !empty($intervention->array_options['options_gestionparc_commercial'])  ? (int) $intervention->array_options['options_gestionparc_commercial']  : 0;
+
+        $intervenant_name = '';
+        $commercial_name  = '';
+
+        if ($intervenant_id > 0) {
+            $u = new User($db);
+            if ($u->fetch($intervenant_id) > 0) $intervenant_name = trim($u->firstname.' '.$u->lastname);
+        }
+        if ($commercial_id > 0) {
+            $u = new User($db);
+            if ($u->fetch($commercial_id) > 0) $commercial_name = trim($u->firstname.' '.$u->lastname);
+        }
+
+        // Repli ancien comportement
+        if (empty($intervenant_name)) {
+            $intervenant_name = trim($user->firstname.' '.$user->lastname);
+            if (empty($intervenant_name)) $intervenant_name = $user->login;
+        }
+        if (empty($commercial_name) && is_object($customer) && method_exists($customer, 'getSalesRepresentatives')) {
+            $parts = array();
+            foreach ($customer->getSalesRepresentatives($user) as $sr) {
+                $parts[] = trim($sr['firstname'].' '.$sr['lastname']);
+            }
+            $commercial_name = implode(' / ', $parts);
+        }
+
+        return array('intervenant' => $intervenant_name, 'commercial' => $commercial_name);
     }
 
     /*****************************************************************/
@@ -1635,12 +2531,14 @@ class GestionParcVerif
         if($resUpdate) :
 
             if($maj_verifid) :
+                // Incrémente si on contrôle (val=1), décrémente si on revient en arrière (val=0)
+                $delta = $val ? 1 : -1;
                 $sql_bis = "UPDATE ".MAIN_DB_PREFIX.$this->table_element;
-                $sql_bis.= " SET nb_verified = nb_verified + 1";
+                $sql_bis.= " SET nb_verified = GREATEST(0, nb_verified + (".$delta."))";
                 $sql_bis.= " WHERE rowid = '".$maj_verifid."'";
                 $res_bis = $this->db->query($sql_bis);
 
-                $this->nb_verified++;
+                $this->nb_verified = max(0, (int) $this->nb_verified + $delta);
 
             endif;
 
@@ -1706,8 +2604,33 @@ class GestionParcVerif
 
     public function cancelVerif($verif_id)
     {
+        $this->ensureVerifSnapshotColumn();
 
-        $sql = "DELETE FROM ".MAIN_DB_PREFIX.$this->table_element." WHERE rowid = ".$verif_id;
+        // Restaure les valeurs d'origine réinitialisées à l'ouverture (force_default_on_verif)
+        $resq = $this->db->query("SELECT socid, reset_backup FROM ".MAIN_DB_PREFIX.$this->table_element." WHERE rowid = ".(int) $verif_id);
+        if ($resq && $this->db->num_rows($resq)) {
+            $vrow = $this->db->fetch_object($resq);
+            if (!empty($vrow->reset_backup)) {
+                $backup = json_decode($vrow->reset_backup, true);
+                if (is_array($backup)) {
+                    $socid = (int) $vrow->socid;
+                    foreach ($backup as $parc_key => $lines) {
+                        if (!preg_match('/^[a-zA-Z0-9_]+$/', $parc_key)) continue;
+                        foreach ($lines as $line_rowid => $cfields) {
+                            foreach ($cfields as $field_key => $old_value) {
+                                if (!preg_match('/^[a-zA-Z0-9_]+$/', $field_key)) continue;
+                                $sql_r = "UPDATE ".MAIN_DB_PREFIX.$this->parent_table_element."__".$this->db->escape($parc_key);
+                                $sql_r .= " SET `".$field_key."` = '".$this->db->escape($old_value)."'";
+                                $sql_r .= " WHERE rowid = ".(int) $line_rowid." AND socid = ".$socid;
+                                $this->db->query($sql_r);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        $sql = "DELETE FROM ".MAIN_DB_PREFIX.$this->table_element." WHERE rowid = ".(int) $verif_id;
         $result = $this->db->query($sql);
 
         if($result) : $this->db->commit(); return true;
@@ -1898,6 +2821,19 @@ class GestionParcVerif
         $intervention->array_options['options_gestionparc_isverif'] = $rowid;
         $intervention->updateExtraField('gestionparc_isverif');
 
+        // Extrafield Fichinter : commercial / intervenant (repris de la campagne)
+        $this->writeInterventionUsers($intervention, $rowid);
+
+        // Extrafields Fichinter : champs personnalisés (snapshot du tiers)
+        $this->writeInterventionCustomSocFields($intervention, $socid);
+
+        // Snapshot des données d'organes en BDD : fige l'état au moment de la
+        // clôture pour que les exports ultérieurs reflètent la vérif d'origine.
+        require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
+        $snap_customer = new Societe($this->db);
+        $snap_customer->fetch($socid);
+        $this->storeVerifSnapshot($rowid, $this->getReportData($gestionparc->list_parcType(1), $snap_customer));
+
         // ON GENERE LE DOCUMENT
         $intervention->generateDocument($this->model_pdf, $langs);
 
@@ -1953,6 +2889,12 @@ class GestionParcVerif
         $intervention->array_options['options_gestionparc_isverif'] = $this->rowid;
         $intervention->updateExtraField('gestionparc_isverif');
 
+        // Extrafield Fichinter : commercial / intervenant (repris de la campagne)
+        $this->writeInterventionUsers($intervention, $this->rowid);
+
+        // Extrafields Fichinter : champs personnalisés (snapshot du tiers)
+        $this->writeInterventionCustomSocFields($intervention, $socid);
+
         // ON VALIDE L'INTERVENTION (la ref provisoire devient la ref définitive ici)
         $blop = $intervention->setValid($user);
 
@@ -1975,6 +2917,10 @@ class GestionParcVerif
         if (file_exists($pdf_file)) dol_delete_file($pdf_file);
         $report_data = $this->getReportData($list_parctypes, $customer);
         $this->_renderPDFReport($intervention, $report_data, $customer, $pdf_file);
+
+        // Snapshot des données d'organes en BDD : fige l'état au moment de la
+        // clôture pour que les exports ultérieurs reflètent la vérif d'origine.
+        $this->storeVerifSnapshot($this->rowid, $report_data);
 
         // ON GENERE LE DOCUMENT (PDF standard Dolibarr de la ficheinter)
         $intervention->generateDocument($this->model_pdf, $langs);
@@ -2034,10 +2980,12 @@ class GestionParcVerif
         $legacy_file = $upload_dir.'/rapport_verification.'.$sheetfile->extension;
         if (file_exists($legacy_file)) dol_delete_file($legacy_file);
 
-
+        // Données figées à la clôture si disponibles (export historique fidèle),
+        // sinon données live (anciennes vérifs sans snapshot).
+        $report_data = $this->getVerifSnapshotByFichinter($fichinter_id);
 
         // Render
-        if ($this->_renderExcelReport($intervention, $list_parctypes, $customer, $dir_file)) {
+        if ($this->_renderExcelReport($intervention, $list_parctypes, $customer, $dir_file, $report_data)) {
             return $dir_file;
         }
 
@@ -2080,8 +3028,12 @@ class GestionParcVerif
         if (file_exists($dir_file)) dol_delete_file($dir_file);
 
 
-        // Get Shared Report Data
-        $report_data = $this->getReportData($list_parctypes, $customer);
+        // Données figées à la clôture si disponibles (export historique fidèle),
+        // sinon données live (anciennes vérifs sans snapshot).
+        $report_data = $this->getVerifSnapshotByFichinter($fichinter_id);
+        if ($report_data === null) {
+            $report_data = $this->getReportData($list_parctypes, $customer);
+        }
 
         // Render
         if ($this->_renderPDFReport($intervention, $report_data, $customer, $dir_file)) {
@@ -2196,9 +3148,10 @@ class GestionParcVerif
      * @param array     $list_parctypes
      * @param Societe   $customer
      * @param string    $dir_file
+     * @param array|null $report_data  Données figées (snapshot) ; si null, lecture live
      * @return bool
      */
-    protected function _renderExcelReport($intervention, $list_parctypes, $customer, $dir_file)
+    protected function _renderExcelReport($intervention, $list_parctypes, $customer, $dir_file, $report_data = null)
     {
         global $db, $langs, $conf;
 
@@ -2206,8 +3159,10 @@ class GestionParcVerif
 
         dol_include_once('gestionparc/class/gestionparcexport.class.php');
         $sheetfile = new GestionParcExport($this->db);
-        
-        $report_data = $this->getReportData($list_parctypes, $customer);
+
+        if (!is_array($report_data)) {
+            $report_data = $this->getReportData($list_parctypes, $customer);
+        }
         $max_cols_global = $report_data['max_cols'];
 
         
@@ -2219,7 +3174,17 @@ class GestionParcVerif
         $full_sheet = $sheetfile->workbook->getActiveSheet();
         $sheetfile->setupSheet($full_sheet, $langs->transnoentities('gp_advexp_fullreport'), $max_cols_global);
         $inter_date = !empty($intervention->dateo) ? $intervention->dateo : (!empty($intervention->datec) ? $intervention->datec : null);
-        $full_row = $sheetfile->customHeader($full_sheet, 1, $max_cols_global, $customer, '', $inter_date);
+        $export_users = self::resolveExportUsers($this->db, $intervention, $customer);
+        $extra_header_rows = array();
+        foreach (self::getCustomSocFields() as $code => $def) {
+            $val = self::resolveCustomSocField($this->db, $code, $intervention, $customer);
+            if ($val !== '') $extra_header_rows[] = array('label' => $langs->transnoentities($def['label']), 'value' => $val);
+        }
+        // En-tête figé (backport) : technicien/commercial/champs client de l'époque, sinon valeurs live
+        $snapHeader = (isset($report_data['header']) && is_array($report_data['header'])) ? $report_data['header'] : array();
+        $hdr_interv = !empty($snapHeader['technicien']) ? $snapHeader['technicien'] : $export_users['intervenant'];
+        $hdr_comm   = !empty($snapHeader['commercial']) ? $snapHeader['commercial'] : $export_users['commercial'];
+        $full_row = $sheetfile->customHeader($full_sheet, 1, $max_cols_global, $customer, '', $inter_date, $hdr_interv, $hdr_comm, $extra_header_rows, $snapHeader);
 
         foreach ($report_data['sections'] as $section) {
             // Render Individual Worksheets
@@ -2239,21 +3204,22 @@ class GestionParcVerif
             $sheet = $sheetfile->workbook->getActiveSheet();
             $sheetfile->setupSheet($sheet, $section['label'], $nb_data_cols);
 
-            $row = $sheetfile->customHeader($sheet, 1, $nb_data_cols, $customer, $section['label'], $inter_date);
+            $row = $sheetfile->customHeader($sheet, 1, $nb_data_cols, $customer, $section['label'], $inter_date, $hdr_interv, $hdr_comm, $extra_header_rows, $snapHeader);
             $row = $sheetfile->writeColumnHeaders($sheet, $row, $col_labels);
 
-            // Render on Consolidated Sheet (each section uses its own column count — no padding)
-            $full_row = $sheetfile->writeSectionTitle($full_sheet, $full_row, $nb_data_cols, $section['label']);
-            $full_row = $sheetfile->writeColumnHeaders($full_sheet, $full_row, $col_labels);
+            // Feuille consolidée : chaque organe occupe la largeur totale (max_cols_global) ;
+            // les organes plus courts fusionnent leur dernière cellule pour la même largeur.
+            $full_row = $sheetfile->writeSectionTitle($full_sheet, $full_row, $max_cols_global, $section['label']);
+            $full_row = $sheetfile->writeColumnHeaders($full_sheet, $full_row, $col_labels, $max_cols_global);
 
             foreach ($section['lines'] as $l_idx => $values) {
                 $isOdd = ($l_idx % 2 === 1);
                 $row      = $sheetfile->writeDataRow($sheet, $row, $values, $isOdd, $align_map);
-                $full_row = $sheetfile->writeDataRow($full_sheet, $full_row, $values, $isOdd, $align_map);
+                $full_row = $sheetfile->writeDataRow($full_sheet, $full_row, $values, $isOdd, $align_map, $max_cols_global);
             }
 
             $row      = $sheetfile->writeSummaryRow($sheet, $row, $section['stats']['verified'], $section['stats']['total'], $nb_data_cols);
-            $full_row = $sheetfile->writeSummaryRow($full_sheet, $full_row, $section['stats']['verified'], $section['stats']['total'], $nb_data_cols);
+            $full_row = $sheetfile->writeSummaryRow($full_sheet, $full_row, $section['stats']['verified'], $section['stats']['total'], $max_cols_global);
             $full_row += 2;
         }
 

--- a/class/gestionparcexport.class.php
+++ b/class/gestionparcexport.class.php
@@ -47,6 +47,10 @@ class GestionParcExport extends ExportExcel2007
 	const COLOR_BORDER_DARK = 'FF173652'; // dark blue — outer borders
 	const COLOR_BORDER_SOFT = 'FFD0D0D0'; // grey — inner cell borders
 
+	// Largeur totale fixe d'un tableau (unités Excel) : garantit que tous les
+	// tableaux ont la même largeur, quel que soit le nombre de colonnes.
+	const TABLE_WIDTH = 145;
+
 	// ── Column index helper ──────────────────────────────────────────────────
 
 	/**
@@ -56,6 +60,58 @@ class GestionParcExport extends ExportExcel2007
 	public function col($index0)
 	{
 		return Coordinate::stringFromColumnIndex($index0 + 1);
+	}
+
+	/**
+	 * Largeurs de colonnes pour atteindre une largeur totale constante (TABLE_WIDTH).
+	 * A=12 (Numéro), B=35 (Produit), C=20 (MES) restent fixes (l'en-tête en dépend) ;
+	 * les colonnes suivantes se partagent le reste à parts égales. Pour <= 3 colonnes,
+	 * la dernière est étirée pour atteindre la largeur totale.
+	 *
+	 * @param int $n  Nombre de colonnes de données
+	 * @return float[]  Largeurs indexées 0..n-1 (somme = TABLE_WIDTH si n >= 1)
+	 */
+	public function dataColWidths($n)
+	{
+		$n = (int) $n;
+		if ($n <= 0) return array();
+
+		$base = array(12, 35, 20);
+		$w = array();
+		for ($i = 0; $i < min($n, 3); $i++) $w[$i] = $base[$i];
+
+		$rest = $n - 3;
+		if ($rest > 0) {
+			$remaining = self::TABLE_WIDTH - array_sum($w);
+			$each = max(14, $remaining / $rest);
+			for ($i = 3; $i < $n; $i++) $w[$i] = round($each, 2);
+		} else {
+			// <= 3 colonnes : on étire la dernière pour atteindre la largeur totale
+			$sum = array_sum($w);
+			if ($sum < self::TABLE_WIDTH) $w[$n - 1] += (self::TABLE_WIDTH - $sum);
+		}
+		return $w;
+	}
+
+	/**
+	 * Hauteur de ligne (pt) calée sur le retour à la ligne réel de chaque cellule,
+	 * d'après la largeur de colonne effective. ~0,92 caractère par unité de largeur
+	 * (police 12). 24pt = 1 ligne, +16pt par ligne supplémentaire.
+	 *
+	 * @param array $values  Valeurs de la ligne
+	 * @param array $widths  Largeurs effectives par colonne (0-based)
+	 * @return int
+	 */
+	protected function computeRowHeight(array $values, array $widths)
+	{
+		$max_lines = 1;
+		foreach (array_values($values) as $i => $v) {
+			$wd  = isset($widths[$i]) ? $widths[$i] : 20;
+			$cpl = max(1, $wd * 0.92);
+			$n   = max(1, (int) ceil(mb_strlen((string) $v) / $cpl));
+			if ($n > $max_lines) $max_lines = $n;
+		}
+		return (int) max(24, 24 + ($max_lines - 1) * 16);
 	}
 
 	// ── Style helpers ────────────────────────────────────────────────────────
@@ -123,17 +179,11 @@ class GestionParcExport extends ExportExcel2007
 	{
 		$sheet->setTitle(mb_strtoupper(mb_substr($title, 0, 31)));
 
-		// Column A and B are fixed for the logo zone
-		$sheet->getColumnDimension('A')->setWidth(12);
-		$sheet->getColumnDimension('B')->setWidth(35);
-
-		// Column C is used for header labels, we give it a modest minimum
-		$sheet->getColumnDimension('C')->setWidth(20);
-
-		// Columns D onwards: AutoSize for data
-		for ($i = 3; $i < $nb_data_cols; $i++) {
-			$col_letter = $this->col($i);
-			$sheet->getColumnDimension($col_letter)->setAutoSize(true);
+		// Largeurs de colonnes fixes : tous les tableaux font la même largeur totale
+		// (A,B,C gardent leurs largeurs pour ne pas casser l'en-tête ; les colonnes
+		// suivantes se répartissent le reste pour atteindre TABLE_WIDTH).
+		foreach ($this->dataColWidths($nb_data_cols) as $i => $wd) {
+			$sheet->getColumnDimension($this->col($i))->setWidth($wd);
 		}
 
 		$sheet->getDefaultRowDimension()->setRowHeight(24);
@@ -182,7 +232,7 @@ class GestionParcExport extends ExportExcel2007
 	 * @param string  $parclabel
 	 * @return int  First row after the header block
 	 */
-	public function customHeader($sheet, $row_start, $nb_data_cols, $customer, $parclabel = '', $inter_date = null)
+	public function customHeader($sheet, $row_start, $nb_data_cols, $customer, $parclabel = '', $inter_date = null, $intervenant_name = null, $commercial_name = null, $extra_rows = array(), $header_override = array())
 	{
 		global $mysoc, $user, $conf, $langs;
 
@@ -195,7 +245,8 @@ class GestionParcExport extends ExportExcel2007
 		// ── Row 1 : Title ────────────────────────────────────────────────
 		$title_range = 'A' . $row . ':' . $H_LAST . $row;
 		$sheet->mergeCells($title_range);
-		$sheet->setCellValue('A' . $row, $langs->transnoentities('gp_advexp_title') . ' ' . date('Y'));
+		$title_year = !empty($inter_date) ? dol_print_date($inter_date, '%Y') : date('Y');
+		$sheet->setCellValue('A' . $row, $langs->transnoentities('gp_advexp_title') . ' ' . $title_year);
 		$this->applyFill($sheet, $title_range, self::COLOR_TITLE_BG);
 		$this->applyFontColor($sheet, $title_range, self::COLOR_TITLE_FG);
 		$sheet->getStyle($title_range)->getFont()->setBold(true)->setSize(20);
@@ -292,25 +343,31 @@ class GestionParcExport extends ExportExcel2007
 		);
 		$row++;
 
+		$intervenant_value = ($intervenant_name !== null && $intervenant_name !== '') ? $intervenant_name : trim($user->firstname . ' ' . $user->lastname);
 		$this->writeInfoRow(
 			$sheet,
 			$row,
 			$H_LAST,
 			$langs->transnoentities('gp_advexp_user'),
-			trim($user->firstname . ' ' . $user->lastname)
+			$intervenant_value
 		);
 		$row++;
 
-		$salesrep_parts = array();
-		foreach ($customer->getSalesRepresentatives($user) as $sr) {
-			$salesrep_parts[] = trim($sr['firstname'] . ' ' . $sr['lastname']);
+		if ($commercial_name !== null && $commercial_name !== '') {
+			$commercial_value = $commercial_name;
+		} else {
+			$salesrep_parts = array();
+			foreach ($customer->getSalesRepresentatives($user) as $sr) {
+				$salesrep_parts[] = trim($sr['firstname'] . ' ' . $sr['lastname']);
+			}
+			$commercial_value = implode(' / ', $salesrep_parts);
 		}
 		$this->writeInfoRow(
 			$sheet,
 			$row,
 			$H_LAST,
 			$langs->transnoentities('gp_advexp_commercial'),
-			implode(' / ', $salesrep_parts)
+			$commercial_value
 		);
 		$row++;
 
@@ -323,11 +380,11 @@ class GestionParcExport extends ExportExcel2007
 			$row,
 			$H_LAST,
 			$langs->transnoentities('Customer'),
-			$customer->nom
+			(!empty($header_override['client']) ? $header_override['client'] : $customer->nom)
 		);
 		$row++;
 
-		$client_address = trim($customer->address . ', ' . $customer->zip . ' ' . $customer->town, ', ');
+		$client_address = !empty($header_override['address']) ? $header_override['address'] : trim($customer->address . ', ' . $customer->zip . ' ' . $customer->town, ', ');
 		$this->writeInfoRow(
 			$sheet,
 			$row,
@@ -342,7 +399,7 @@ class GestionParcExport extends ExportExcel2007
 			$row,
 			$H_LAST,
 			$langs->transnoentities('Phone'),
-			!empty($customer->phone) ? $customer->phone : '—'
+			(!empty($header_override['phone']) ? $header_override['phone'] : (!empty($customer->phone) ? $customer->phone : '—'))
 		);
 		$row++;
 
@@ -351,7 +408,7 @@ class GestionParcExport extends ExportExcel2007
 			$row,
 			$H_LAST,
 			$langs->transnoentities('CustomerCode'),
-			$customer->code_client
+			(!empty($header_override['code_client']) ? $header_override['code_client'] : $customer->code_client)
 		);
 		$row++;
 
@@ -364,6 +421,20 @@ class GestionParcExport extends ExportExcel2007
 				$parclabel
 			);
 			$row++;
+		}
+
+		// Champs personnalisés (bas du header)
+		if (!empty($extra_rows) && is_array($extra_rows)) {
+			foreach ($extra_rows as $extra_row) {
+				$this->writeInfoRow(
+					$sheet,
+					$row,
+					$H_LAST,
+					$extra_row['label'],
+					$extra_row['value']
+				);
+				$row++;
+			}
 		}
 
 		if (empty($parclabel)) {
@@ -438,12 +509,14 @@ class GestionParcExport extends ExportExcel2007
 	 */
 	protected function writeInfoRow($sheet, $row, $h_last, $label, $value, $val_align = 'left')
 	{
-		// Label cell (C ONLY - no merge with D)
+		// Label cell (C ONLY - no merge with D). Retour à la ligne pour les libellés
+		// longs (ex. "Référentiel de conformité") qui dépassent la largeur de la colonne C.
 		$sheet->setCellValue('C' . $row, $label);
 		$sheet->getStyle('C' . $row)->getFont()->setBold(true)->setSize(13);
 		$this->applyFontColor($sheet, 'C' . $row, self::COLOR_INFO_LABEL);
 		$sheet->getStyle('C' . $row)->getAlignment()
-			->setVertical(Alignment::VERTICAL_CENTER);
+			->setVertical(Alignment::VERTICAL_CENTER)
+			->setWrapText(true);
 
 		// Value cell (D:h_last merged)
 		$val_range = 'D' . $row . ':' . $h_last . $row;
@@ -458,14 +531,15 @@ class GestionParcExport extends ExportExcel2007
 			->setWrapText(true);
 
 		// Excel auto-fit row height does not work on merged cells.
-		// We must estimate the required height manually.
-		$lines = 0;
+		// We must estimate the required height manually, en tenant compte du
+		// retour à la ligne de la valeur ET du libellé (colonne C, largeur ~20).
+		$value_lines = 0;
 		$val_norm = str_replace(array("\r\n", "\r"), "\n", $value);
-		$texts = explode("\n", $val_norm);
-		foreach ($texts as $t) {
-			// Assume the merged column might be narrow (around 30-35 chars per line)
-			$lines += max(1, ceil(mb_strlen($t) / 30));
+		foreach (explode("\n", $val_norm) as $t) {
+			$value_lines += max(1, ceil(mb_strlen($t) / 30));
 		}
+		$label_lines = max(1, (int) ceil(mb_strlen((string) $label) / 17)); // C ~20, gras 13pt
+		$lines = max($value_lines, $label_lines);
 		$estimated_height = max(24, $lines * 18 + 6);
 		$sheet->getRowDimension($row)->setRowHeight($estimated_height);
 
@@ -498,9 +572,12 @@ class GestionParcExport extends ExportExcel2007
 	 * @param array $col_labels  Ordered list of column labels
 	 * @return int  Next row number
 	 */
-	public function writeColumnHeaders($sheet, $row, array $col_labels)
+	public function writeColumnHeaders($sheet, $row, array $col_labels, $sheet_cols = 0)
 	{
-		$nb = count($col_labels);
+		$col_labels = array_values($col_labels);
+		$ncol = count($col_labels);
+		if ($sheet_cols < $ncol) $sheet_cols = $ncol;
+
 		$col_idx = 0;
 		foreach ($col_labels as $label) {
 			$cell = $this->col($col_idx) . $row;
@@ -518,6 +595,18 @@ class GestionParcExport extends ExportExcel2007
 				->getColor()->setARGB(self::COLOR_BORDER_DARK);
 			$col_idx++;
 		}
+
+		// Fusion de la dernière colonne d'en-tête sur les colonnes restantes (consolidé)
+		if ($sheet_cols > $ncol) {
+			for ($k = $ncol; $k < $sheet_cols; $k++) {
+				$c2 = $this->col($k) . $row;
+				$this->applyFill($sheet, $c2, self::COLOR_COLHDR_BG);
+				$sheet->getStyle($c2)->getBorders()->getAllBorders()
+					->setBorderStyle(Border::BORDER_THIN)->getColor()->setARGB(self::COLOR_BORDER_DARK);
+			}
+			$sheet->mergeCells($this->col($ncol - 1) . $row . ':' . $this->col($sheet_cols - 1) . $row);
+		}
+
 		// Outer border on the whole header row
 		$sheet->getRowDimension($row)->setRowHeight(28); // Refined header height
 		return $row + 1;
@@ -536,12 +625,28 @@ class GestionParcExport extends ExportExcel2007
 	 * @param array      $align_map   0-based col index => 'left'|'center'|'right'
 	 * @return int  Next row number
 	 */
-	public function writeDataRow($sheet, $row, array $values, $isOdd, array $align_map = array())
+	public function writeDataRow($sheet, $row, array $values, $isOdd, array $align_map = array(), $sheet_cols = 0)
 	{
 		$row_bg = $isOdd ? self::COLOR_ROW_ODD : 'FFFFFFFF';
+		$values = array_values($values);
+		$ncol   = count($values);
+		if ($sheet_cols < $ncol) $sheet_cols = $ncol;
 
-		// Refined row height (between standard 15 and previous 38)
-		$sheet->getRowDimension($row)->setRowHeight(24);
+		// Largeurs (du tableau complet) ; la dernière cellule fusionne les colonnes
+		// restantes quand la section a moins de colonnes que la feuille (consolidé).
+		$widths = $this->dataColWidths($sheet_cols);
+		$eff = array();
+		for ($i = 0; $i < $ncol; $i++) {
+			if ($i === $ncol - 1 && $sheet_cols > $ncol) {
+				$wsum = 0; for ($k = $ncol - 1; $k < $sheet_cols; $k++) $wsum += isset($widths[$k]) ? $widths[$k] : 0;
+				$eff[$i] = $wsum;
+			} else {
+				$eff[$i] = isset($widths[$i]) ? $widths[$i] : 20;
+			}
+		}
+
+		// Hauteur adaptée au retour à la ligne réel de chaque cellule
+		$sheet->getRowDimension($row)->setRowHeight($this->computeRowHeight($values, $eff));
 
 		$col_idx = 0;
 		foreach ($values as $value) {
@@ -550,16 +655,14 @@ class GestionParcExport extends ExportExcel2007
 			$sheet->getStyle($cell)->getFont()->setSize(12);
 			$this->applyFill($sheet, $cell, $row_bg);
 
-			// Enable wrapping ONLY for the 'Produit' column (Index 1)
-			$wrap = ($col_idx === 1);
+			// Retour à la ligne sur les colonnes texte (pas le Numéro)
+			$wrap = ($col_idx !== 0);
 			$sheet->getStyle($cell)->getAlignment()
 				->setWrapText($wrap)
 				->setVertical(Alignment::VERTICAL_CENTER);
-			// Soft inner borders
 			$sheet->getStyle($cell)->getBorders()->getAllBorders()
 				->setBorderStyle(Border::BORDER_HAIR)
 				->getColor()->setARGB(self::COLOR_BORDER_SOFT);
-			// Left border slightly stronger for readability
 			$sheet->getStyle($cell)->getBorders()->getLeft()
 				->setBorderStyle(Border::BORDER_THIN)
 				->getColor()->setARGB(self::COLOR_BORDER_SOFT);
@@ -576,7 +679,6 @@ class GestionParcExport extends ExportExcel2007
 						break;
 				}
 			} else {
-				// Auto-center years, numbers, and dates (XX/XX/XXXX)
 				$clean_val = trim((string) $value);
 				if (is_numeric($clean_val) || preg_match('/^\d{2}\/\d{2}\/\d{4}$/', $clean_val)) {
 					$h = Alignment::HORIZONTAL_CENTER;
@@ -584,6 +686,18 @@ class GestionParcExport extends ExportExcel2007
 			}
 			$sheet->getStyle($cell)->getAlignment()->setHorizontal($h);
 			$col_idx++;
+		}
+
+		// Fusion de la dernière cellule sur les colonnes restantes (sections plus
+		// courtes de la feuille consolidée) pour conserver la même largeur totale.
+		if ($sheet_cols > $ncol) {
+			for ($k = $ncol; $k < $sheet_cols; $k++) {
+				$c2 = $this->col($k) . $row;
+				$this->applyFill($sheet, $c2, $row_bg);
+				$sheet->getStyle($c2)->getBorders()->getAllBorders()
+					->setBorderStyle(Border::BORDER_HAIR)->getColor()->setARGB(self::COLOR_BORDER_SOFT);
+			}
+			$sheet->mergeCells($this->col($ncol - 1) . $row . ':' . $this->col($sheet_cols - 1) . $row);
 		}
 
 		return $row + 1;

--- a/class/gestionparcpdf.class.php
+++ b/class/gestionparcpdf.class.php
@@ -34,6 +34,7 @@ class GestionParcPDF extends TCPDF
     private $db;
     /** @var object */  private $intervention;
     /** @var object */  private $customer;
+    /** @var array */   private $headerOverride = array();
 
     // ── Palette — identical to GestionParcExport constants ─────────────────
     const TITLE_BG   = array(23,  54,  82);
@@ -166,6 +167,7 @@ class GestionParcPDF extends TCPDF
 
         $this->intervention = $intervention;
         $this->customer     = $customer;
+        $this->headerOverride = (isset($report_data['header']) && is_array($report_data['header'])) ? $report_data['header'] : array();
 
         // Ensure translation keys from companies / bills are available
         $langs->loadLangs(array('companies', 'bills'));
@@ -184,8 +186,8 @@ class GestionParcPDF extends TCPDF
         $this->AddPage();
         $this->drawInfoBlock($intervention, $customer);
 
-        foreach ($report_data['sections'] as $section) {
-            $this->drawSection($section);
+        foreach ($report_data['sections'] as $idx => $section) {
+            $this->drawSection($section, ($idx === 0));
         }
 
         $this->Output($output_file, 'F');
@@ -222,6 +224,9 @@ class GestionParcPDF extends TCPDF
         $w  = self::CW;
         $y  = $this->GetY();
 
+        // ── Info rows data preparation ────────────────────────────────────
+        $inter_date = !empty($intervention->dateo) ? $intervention->dateo : (!empty($intervention->datec) ? $intervention->datec : dol_stringtotime(date('Y-m-d')));
+
         // ── Row 1: Title bar ─────────────────────────────────────────────
         $th = 11;
         $this->sf(self::TITLE_BG);
@@ -232,27 +237,23 @@ class GestionParcPDF extends TCPDF
         $this->Cell(
             $w,
             $th,
-            mb_strtoupper($this->t($langs->trans('gp_advexp_title'))) . ' ' . date('Y'),
+            mb_strtoupper($this->t($langs->trans('gp_advexp_title'))) . ' ' . dol_print_date($inter_date, '%Y'),
             0,
             1,
             'C'
         );
         $y += $th;
 
-        // ── Info rows data preparation ────────────────────────────────────
-        $inter_date = !empty($intervention->dateo) ? $intervention->dateo : (!empty($intervention->datec) ? $intervention->datec : dol_stringtotime(date('Y-m-d')));
+        if (!class_exists('GestionParcVerif')) dol_include_once('/gestionparc/class/gestionparc.class.php');
+        $export_users = GestionParcVerif::resolveExportUsers($this->db, $intervention, $customer);
+        $ho = $this->headerOverride; // en-tête figé (backport) si présent
+        $tech     = !empty($ho['technicien']) ? $ho['technicien'] : $export_users['intervenant'];
+        $salesrep = !empty($ho['commercial']) ? $ho['commercial'] : $export_users['commercial'];
 
-        $tech = trim((string)$user->firstname . ' ' . (string)$user->lastname);
-        if (empty($tech)) $tech = $user->login;
-
-        $salesrep = '';
-        if (method_exists($customer, 'getSalesRepresentatives')) {
-            foreach ($customer->getSalesRepresentatives($user) as $sr) {
-                $salesrep .= ($salesrep ? ' / ' : '') . trim($sr['firstname'] . ' ' . $sr['lastname']);
-            }
-        }
-
-        $addr_client = trim($this->t($customer->address) . ', ' . trim($customer->zip . ' ' . $this->t($customer->town)), ', ');
+        $cust_name    = !empty($ho['client'])      ? $ho['client']      : $customer->name;
+        $addr_client  = !empty($ho['address'])     ? $ho['address']     : trim($this->t($customer->address) . ', ' . trim($customer->zip . ' ' . $this->t($customer->town)), ', ');
+        $cust_phone   = !empty($ho['phone'])       ? $ho['phone']       : (!empty($customer->phone) ? $customer->phone : '—');
+        $cust_code    = !empty($ho['code_client']) ? $ho['code_client'] : $customer->code_client;
 
         // 7 info rows + 1 spacer at position 3 (0-indexed)
         $info_rows = array(
@@ -260,11 +261,19 @@ class GestionParcPDF extends TCPDF
             array($this->t($langs->trans('gp_advexp_user')),       $this->t($tech)),
             array($this->t($langs->trans('gp_advexp_commercial')), $this->t($salesrep)),
             null,   // spacer
-            array($this->t($langs->trans('Customer')),             $this->t($customer->name)),
-            array($this->t($langs->trans('Address')),              $addr_client),
-            array($this->t($langs->trans('Phone')),                  !empty($customer->phone) ? $customer->phone : '—'),
-            array($this->t($langs->trans('CustomerCode')),         $customer->code_client),
+            array($this->t($langs->trans('Customer')),             $this->t($cust_name)),
+            array($this->t($langs->trans('Address')),              $this->t($addr_client)),
+            array($this->t($langs->trans('Phone')),                  $cust_phone),
+            array($this->t($langs->trans('CustomerCode')),         $cust_code),
         );
+
+        // Champs personnalisés (bas du header)
+        foreach (GestionParcVerif::getCustomSocFields() as $code => $def) {
+            $val = GestionParcVerif::resolveCustomSocField($this->db, $code, $intervention, $customer);
+            if ($val !== '') {
+                $info_rows[] = array($this->t($langs->trans($def['label'])), $this->t($val));
+            }
+        }
 
         // ── Geometry ─────────────────────────────────────────────────────
         $logo_w = 58;   // A:B equivalent
@@ -427,9 +436,15 @@ class GestionParcPDF extends TCPDF
     //   └──────────────────────────────────── 6 / 6 élément(s) vérifié(s) ┘  E8E8E8
     // ─────────────────────────────────────────────────────────────────────
 
-    private function drawSection($section)
+    private function drawSection($section, $isFirst = false)
     {
-        if ($this->GetY() > 238) $this->AddPage();
+        // Chaque organe démarre sur une nouvelle page (même s'il reste de la place).
+        // Le 1er organe reste sous l'en-tête de la page 1 (sauf si la place y est trop juste).
+        if (!$isFirst) {
+            $this->AddPage();
+        } elseif ($this->GetY() > 238) {
+            $this->AddPage();
+        }
 
         $col_widths = $this->calcColWidths($section['fields']);
         $x0 = self::ML;
@@ -456,20 +471,34 @@ class GestionParcPDF extends TCPDF
         $this->SetLineWidth(0.2);
 
         // ── Column headers (navy bg + white text — exact Excel COLHDR style) ──
-        $table_top  = $this->GetY();
-        $start_page = $this->getPage();
+        $bottom_limit = $this->getPageHeight() - 18;
+        $table_top    = $this->GetY();
         $this->drawColHeaders($section['fields'], $col_widths);
+        $page_top = $table_top; // haut du tableau sur la page courante (pour la bordure)
 
         // ── Data rows ─────────────────────────────────────────────────────
+        // Saut de page géré ici : on ferme la bordure de la page courante, on
+        // passe à la page suivante et on répète les en-têtes de colonnes.
         foreach ($section['lines'] as $idx => $values) {
+            $row_h = $this->calcRowHeight($values, $col_widths);
+            if ($this->GetY() + $row_h > $bottom_limit) {
+                $this->drawSectionBorder($x0, $page_top, $w, $this->GetY() - $page_top);
+                $this->AddPage();
+                $page_top = $this->GetY();
+                $this->drawColHeaders($section['fields'], $col_widths);
+            }
             $this->drawDataRow($values, $col_widths, ($idx % 2 === 1));
         }
 
         // ── Summary row ───────────────────────────────────────────────────
+        $sum_h = 8;
+        if ($this->GetY() + $sum_h > $bottom_limit) {
+            $this->drawSectionBorder($x0, $page_top, $w, $this->GetY() - $page_top);
+            $this->AddPage();
+            $page_top = $this->GetY();
+        }
         $y_sum   = $this->GetY();
-        $sum_h   = 8;
         $sum_txt = $section['stats']['verified'] . ' / ' . $section['stats']['total'] . ' élément(s) vérifié(s)';
-
         $this->sf(self::SUMMARY_BG);
         $this->Rect($x0, $y_sum, $w, $sum_h, 'F');
         $this->SetFont('helvetica', 'B', 8.5);
@@ -477,17 +506,45 @@ class GestionParcPDF extends TCPDF
         $this->SetXY($x0, $y_sum);
         $this->Cell($w - 4, $sum_h, $sum_txt, 0, 1, 'R');
 
-        // ── Outer border: only draw when the whole section fits on one page ─
-        // If a page break occurred during data rows, table_top belongs to a
-        // previous page and the Rect coordinates would be meaningless / produce
-        // a ghost rectangle. In that case we skip it.
-        if ($this->getPage() === $start_page) {
-            $this->sd(self::BDR_DARK);
-            $this->SetLineWidth(0.55);
-            $this->Rect($x0, $table_top, $w, $this->GetY() - $table_top, 'D');
-        }
+        // ── Bordure extérieure navy sur la (dernière) page du tableau ──
+        $this->drawSectionBorder($x0, $page_top, $w, $this->GetY() - $page_top);
 
         $this->Ln(8);
+    }
+
+    /** Dessine la bordure extérieure navy d'un bloc de tableau. */
+    private function drawSectionBorder($x, $y, $w, $h)
+    {
+        if ($h <= 0) return;
+        $this->sd(self::BDR_DARK);
+        $this->SetLineWidth(0.55);
+        $this->Rect($x, $y, $w, $h, 'D');
+        $this->SetLineWidth(0.2);
+    }
+
+    /**
+     * Hauteur d'une ligne de données, calée sur le rendu réel de MultiCell :
+     * nb de lignes (au plus large) × hauteur de ligne ($line_h) + padding vertical.
+     * On fixe la même police et le même padding que drawDataRow pour que
+     * getNumLines() compte exactement comme MultiCell, évitant troncature et
+     * espacements incohérents.
+     */
+    private function calcRowHeight($values, $col_widths)
+    {
+        $line_h = 5.0;   // hauteur d'une ligne rendue par MultiCell
+        $min_h  = 7.0;   // hauteur minimale d'une ligne
+        $vpad   = 3.0;   // padding vertical (1.5 haut + 1.5 bas)
+
+        $this->SetFont('helvetica', '', 8.5);
+        $this->setCellPaddings(3, 1.5, 2, 1.5); // identique au rendu
+
+        $max_lines = 1;
+        for ($c = 0; $c < count($values); $c++) {
+            $n = $this->getNumLines($this->t((string) $values[$c]), $col_widths[$c]);
+            if ($n > $max_lines) $max_lines = $n;
+        }
+
+        return max($min_h, $max_lines * $line_h + $vpad);
     }
 
     // ── Column headers — navy bg, white text, white internal dividers ─────
@@ -525,20 +582,11 @@ class GestionParcPDF extends TCPDF
     private function drawDataRow($values, $col_widths, $isOdd)
     {
         $line_h = 5.0;  // height of ONE line passed to MultiCell
-        $min_h  = 7.0;  // minimum total row height
 
         $this->SetFont('helvetica', '', 8.5);
 
-        // Calculate total row height = max across all cells of their wrapped height
-        $row_h = $min_h;
-        for ($c = 0; $c < count($values); $c++) {
-            $h = $this->getStringHeight($col_widths[$c] - 5, $this->t((string)$values[$c]));
-            if ($h > $row_h) $row_h = $h;
-        }
-
-        if ($this->GetY() + $row_h > $this->getPageHeight() - 18) {
-            $this->AddPage();
-        }
+        // Hauteur de la ligne (le saut de page est géré en amont par drawSection)
+        $row_h = $this->calcRowHeight($values, $col_widths);
 
         $y  = $this->GetY();
         $x0 = self::ML;

--- a/core/modules/modGestionParc.class.php
+++ b/core/modules/modGestionParc.class.php
@@ -67,7 +67,7 @@ class modGestionParc extends DolibarrModules
         $this->editor_url = 'https://progiseize.fr';
 
         // Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-        $this->version = '1.8.4';
+        $this->version = '1.9.0';
         $this->url_last_version ="	https://modules-api.progiseize.fr/modules/version/300320";
 
         // Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
@@ -378,10 +378,27 @@ class modGestionParc extends DolibarrModules
     public function init($options='')
     {
 
-        global $conf, $db;
+        global $conf, $db, $langs;
         //dolibarr_set_const($db, "CHECKLASTVERSION_EXTERNALMODULE", '1', 'int', 0, '', $conf->entity);
 
         $this->_load_tables('/gestionparc/sql/');
+
+        // Provisionne / migre les extrafields fichinter de vérification + backfill (si le mode verif est actif)
+        if (getDolGlobalInt('MAIN_MODULE_GESTIONPARC_USEVERIF')) {
+            dol_include_once('/gestionparc/class/gestionparc.class.php');
+            $verifsetup = new GestionParcVerif($db);
+            $verifsetup->ensureInterventionExtrafields();
+            $verifsetup->ensureVerifSnapshotColumn();
+        }
+
+        // Provisionne l'extrafield societe "Référentiel de conformité" (indépendant du mode vérif)
+        dol_include_once('/gestionparc/class/gestionparc.class.php');
+        $gpsetup = new GestionParcVerif($db);
+        $gpsetup->ensureSocieteExtrafields();
+
+        // Ajoute la colonne manual_position aux tables par-parc (tri par défaut sur la numérotation)
+        $gpparc = new GestionParc($db);
+        $gpparc->ensureManualPositionColumn();
 
         $sql = array();
         return $this->_init($sql, $options);
@@ -402,4 +419,3 @@ class modGestionParc extends DolibarrModules
     }
 
 }
-

--- a/langs/en_US/gestionparc.lang
+++ b/langs/en_US/gestionparc.lang
@@ -25,6 +25,10 @@ gestionparc_desclong=Customer Asset Management. Assign and model data related to
 # MODELE
 gp_model_desc=Model supporting asset management verifications
 gp_extrafieldFichInter_isverif=Verification identifier
+gp_extrafieldFichInter_commercial=Sales representative
+gp_extrafieldFichInter_intervenant=Technician
+gp_referentiel_conformite=Compliance framework
+gp_typedeplan=Plan type
 
 # BOX
 gp_boxNb_title=Customer Base Management
@@ -38,10 +42,15 @@ gp_clientparc=Customer Base
 gp_showEmptyParcs=Show empty bases
 gp_client_verifmode=Verification mode
 gp_client_lastverif=Last verification
+gp_users_block_title=Sales rep. / Technician
+gp_users_saved=Sales representative / technician saved
 gp_verifcom=Add a comment on the intervention
 gp_verif_open=Activate verification
 gp_verif_close=Close verification
 gp_verif_cancel=Cancel verification
+gp_verif_uncontrolled_title=Uncontrolled components
+gp_verif_confirm_uncontrolled=Some components have not been controlled. Do you still want to close the verification?
+gp_verif_continue_anyway=Continue anyway
 gp_verif_label=Verification
 gp_product_unknown=Unknown product
 gp_empty_parclist_message=It appears that no bases are active for this third party
@@ -52,10 +61,15 @@ GestionParcListView=List view
 gp_verif_error_twice=Two verification instances are open for this third party.
 gp_verif_error_needIntercom=You must enter a reason for closure.
 gp_verif_error_needDuration=You must enter an intervention duration.
+gp_verif_error_needSocField=You must select at least one option for "%s" on the thirdparty before validating the intervention.
 gp_verif_error_onclose=Error closing the verification.
 gp_verif_success_onclose=Intervention "%s" validated.
 gp_verif_success_oncancel=Verification successfully cancelled
 gp_verifline_success=Item verified.
+gp_verifline_reverted=Check reverted.
+gp_verif_verify=Verify
+gp_verif_verified=Component checked
+gp_verif_revert=Undo check
 gp_verifall=Mark all items in this portfolio as verified.
 gp_confirmVerifAll=Please confirm your action.
 
@@ -206,6 +220,20 @@ gp_repairTitle=Repair - Fleet Management
 gp_repairText=Click this button to repair the tables.
 gp_repairButton=Repair
 gp_repairSuccessMsg=Full Repair
+gp_backportTitle=Rebuild verification history (snapshots)
+gp_backportDesc=Rebuilds the frozen data (header + items) of closed verifications from the XLSX reports already generated in each intervention, so their export reflects the original state. Run the preview first (nothing is written), then apply.
+gp_backportForce=Overwrite existing snapshots
+gp_backportDryRun=Preview (dry-run)
+gp_backportRun=Apply
+gp_backportStatTotal=Closed verifications scanned
+gp_backportStatParsed=XLSX reports read successfully
+gp_backportStatWritten=Snapshots written
+gp_backportStatSkipped=Skipped (snapshot already present)
+gp_backportStatNoXlsx=No XLSX report (older CSV verifications)
+gp_backportStatEmpty=Empty / unreadable reports
+gp_backportStatSuspect=Suspect XLSX (modified after close)
+gp_backportDoneCommit=%d snapshot(s) written
+gp_backportDoneDryRun=Preview done - nothing written. Click "Apply" to save.
 
 # EXPORT
 gp_advexp_title=VERIFICATION REPORT

--- a/langs/fr_FR/gestionparc.lang
+++ b/langs/fr_FR/gestionparc.lang
@@ -25,6 +25,10 @@ gestionparc_desclong=Gestion de parc client. Assignez et modéliser des données
 # MODELE
 gp_model_desc=Modèle prenant en charge les vérifications gestion de parc
 gp_extrafieldFichInter_isverif=Identifiant vérification
+gp_extrafieldFichInter_commercial=Commercial
+gp_extrafieldFichInter_intervenant=Intervenant
+gp_referentiel_conformite=Référentiel de conformité
+gp_typedeplan=Type de plan
 
 # BOX
 gp_boxNb_title=Gestion des parcs clients
@@ -38,10 +42,15 @@ gp_clientparc=Parc Client
 gp_showEmptyParcs=Afficher les parcs vides
 gp_client_verifmode=Mode vérification
 gp_client_lastverif=Dernière vérification
+gp_users_block_title=Commercial / Intervenant
+gp_users_saved=Commercial / intervenant enregistrés
 gp_verifcom=Ajouter un commentaire sur l'intervention
 gp_verif_open=Activer vérification
 gp_verif_close=Clôturer vérification
 gp_verif_cancel=Annuler vérification
+gp_verif_uncontrolled_title=Organes non contrôlés
+gp_verif_confirm_uncontrolled=Certains organes n'ont pas été contrôlés. Voulez-vous quand même clôturer la vérification ?
+gp_verif_continue_anyway=Continuer quand même
 gp_verif_label=Vérification
 gp_product_unknown=Produit inconnu
 gp_empty_parclist_message=Il semblerait qu'aucun parc ne soit actif pour ce tiers
@@ -52,10 +61,15 @@ GestionParcListView=Vue Liste
 gp_verif_error_twice=Deux instances de vérifications sont ouvertes pour ce tiers.
 gp_verif_error_needIntercom=Vous devez saisir une raison de clôture
 gp_verif_error_needDuration=Vous devez saisir une duree d'intervention
+gp_verif_error_needSocField=Vous devez cocher au moins une option pour « %s » sur la fiche tiers avant de valider l'intervention.
 gp_verif_error_onclose=Erreur lors de la clôture de la vérification.
 gp_verif_success_onclose=Intervention "%s" validée
 gp_verif_success_oncancel=Verification annulée avec succès
 gp_verifline_success=Item vérifié
+gp_verifline_reverted=Contrôle annulé
+gp_verif_verify=Vérifier
+gp_verif_verified=Élément vérifié
+gp_verif_revert=Annuler le contrôle
 gp_verifall=Marquer tous les éléments de ce parc comme vérifiés
 gp_confirmVerifAll=Merci de confirmer votre action
 
@@ -162,7 +176,7 @@ gp_field_onlyverif_desc=Ce champ sera visible uniquement en mode vérification. 
 gp_field_required_manual_verif=Obligatoire en vérification manuelle
 gp_field_required_manual_verif_desc=En mode vérification manuelle, ce champ devra être obligatoirement rempli pour valider la vérification de l'élément
 gp_field_force_default_on_verif=Forcer la valeur par défaut à chaque vérification
-gp_field_force_default_on_verif_desc=Lors de l'ouverture d'une nouvelle vérification, ce champ sera automatiquement remis à sa valeur par défaut
+gp_field_force_default_on_verif_desc=Lors de l'ouverture d'une nouvelle vérification, ce champ sera automatiquement remis à sa valeur par défaut (si la valeur par défaut est vide, le champ est vidé)
 gp_field_date_help=Format FR ou US / dd/mm/YYYY ou YYYY_mm_dd pour la date du jour
 
 # RETOURS / ERREURS
@@ -218,6 +232,20 @@ gp_repairTitle=Réparation - GestionParc
 gp_repairText=Cliquez sur ce bouton pour réparer les tables.
 gp_repairButton=Réparer
 gp_repairSuccessMsg=Réparation complète
+gp_backportTitle=Reconstruire l'historique des vérifications (snapshots)
+gp_backportDesc=Reconstruit les données figées (en-tête + organes) des vérifications clôturées à partir des rapports XLSX déjà générés dans chaque intervention, pour que leur export reflète l'état d'origine. Lancez d'abord l'aperçu (rien n'est écrit), puis appliquez.
+gp_backportForce=Réécrire les snapshots existants
+gp_backportDryRun=Aperçu (dry-run)
+gp_backportRun=Appliquer
+gp_backportStatTotal=Vérifications clôturées analysées
+gp_backportStatParsed=Rapports XLSX lus avec succès
+gp_backportStatWritten=Snapshots écrits
+gp_backportStatSkipped=Ignorées (snapshot déjà présent)
+gp_backportStatNoXlsx=Sans rapport XLSX (anciennes vérifs CSV)
+gp_backportStatEmpty=Rapports vides / illisibles
+gp_backportStatSuspect=XLSX suspects (modifiés après la clôture)
+gp_backportDoneCommit=%d snapshot(s) écrit(s)
+gp_backportDoneDryRun=Aperçu terminé - aucune écriture. Cliquez sur « Appliquer » pour enregistrer.
 
 # EXPORT
 gp_advexp_title=RAPPORT DE VERIFICATION

--- a/scripts/backport_snapshots.php
+++ b/scripts/backport_snapshots.php
@@ -1,0 +1,49 @@
+<?php
+/* Copyright (C) 2026 Progiseize
+ *
+ * Backport des snapshots de vérification (report_snapshot) à partir des
+ * rapports XLSX historiques générés par le module dans chaque intervention.
+ *
+ * Wrapper CLI : bootstrappe Dolibarr et appelle GestionParcVerif::backportSnapshots().
+ * La même logique est exposée dans Configuration > GestionParc > Réparation.
+ *
+ * Lancer (dans le conteneur / sur le serveur Dolibarr) :
+ *   php custom/gestionparc/scripts/backport_snapshots.php [--commit] [--force] [--limit=N]
+ *
+ *   (sans --commit : dry-run, n'écrit rien)
+ */
+
+if (substr(php_sapi_name(), 0, 3) !== 'cli') { echo "CLI only\n"; exit(1); }
+
+$commit = false; $force = false; $limit = 0;
+foreach (array_slice($argv, 1) as $a) {
+    if ($a === '--commit') $commit = true;
+    elseif ($a === '--force') $force = true;
+    elseif (preg_match('/^--limit=(\d+)$/', $a, $m)) $limit = (int) $m[1];
+}
+
+// Bootstrap Dolibarr
+if (!defined('NOSESSION')) define('NOSESSION', '1');
+$res = 0;
+$tmp = realpath(__DIR__);
+$candidates = array(
+    __DIR__.'/../../../master.inc.php',   // custom/gestionparc/scripts -> htdocs
+    __DIR__.'/../../../../master.inc.php',
+    __DIR__.'/../../../main.inc.php',
+);
+foreach ($candidates as $c) { if (file_exists($c)) { $res = @include $c; if ($res) break; } }
+if (!$res) { fwrite(STDERR, "master.inc.php introuvable (lancez depuis l'arborescence Dolibarr)\n"); exit(1); }
+
+dol_include_once('/gestionparc/class/gestionparc.class.php');
+
+echo "=== Backport snapshots de vérification (XLSX) ".($commit ? "[COMMIT]" : "[DRY-RUN]")." ===\n";
+
+$gpverif = new GestionParcVerif($db);
+$stats = $gpverif->backportSnapshots($commit, $force, $limit);
+
+echo "\n=== Résumé ===\n";
+foreach ($stats as $k => $v) echo str_pad($k, 16).": $v\n";
+if (!$commit) echo "\n(DRY-RUN : rien écrit. Relancer avec --commit pour appliquer.)\n";
+
+$db->close();
+exit(0);

--- a/sql/llx_gestionparc_verifs.sql
+++ b/sql/llx_gestionparc_verifs.sql
@@ -37,3 +37,7 @@ ALTER TABLE llx_gestionparc_verifs CHANGE commentaires commentaires text CHARACT
 ALTER TABLE llx_gestionparc_verifs CHANGE fichinter_id fichinter_id int NOT NULL DEFAULT '0';
 ALTER TABLE llx_gestionparc_verifs CHANGE is_close is_close int NOT NULL DEFAULT '0';
 ALTER TABLE llx_gestionparc_verifs CHANGE files_list files_list JSON NULL DEFAULT NULL;
+ALTER TABLE llx_gestionparc_verifs ADD commercial int NOT NULL DEFAULT 0;
+ALTER TABLE llx_gestionparc_verifs ADD intervenant int NOT NULL DEFAULT 0;
+ALTER TABLE llx_gestionparc_verifs ADD report_snapshot MEDIUMTEXT NULL DEFAULT NULL;
+ALTER TABLE llx_gestionparc_verifs ADD reset_backup MEDIUMTEXT NULL DEFAULT NULL;

--- a/tabs/gestionparc.php
+++ b/tabs/gestionparc.php
@@ -91,6 +91,81 @@ switch ($action):
 		}
 		break;
 
+	// ENREGISTRER UN CHAMP (commercial ou intervenant) - campagne en cours ou dernière intervention
+	case 'gp_set_user':
+
+		if (GETPOST('token') != $_SESSION['token']) {
+			$error++; setEventMessages($langs->trans('SecurityTokenHasExpiredSoActionHasBeenCanceledPleaseRetry'), null, 'warnings');
+		}
+		if (!$user->hasRight('gestionparc', 'parc', 'verif') && !$user->admin) {
+			$error++; setEventMessages($langs->trans('NotEnoughPermissions'), null, 'warnings');
+		}
+
+		$gp_field = GETPOST('gp_field', 'aZ09');
+		if (!in_array($gp_field, array('commercial', 'intervenant'))) {
+			$error++;
+		}
+
+		if (!$error) {
+			$gp_value = GETPOST('gp_value', 'int');
+			$target_verif = GETPOST('gp_verif_id', 'int');
+			$target_fichinter = GETPOST('gp_fichinter_id', 'int');
+
+			if ($target_verif > 0) {
+				$verification->updateVerifUserField($target_verif, $gp_field, $gp_value);
+			} elseif ($target_fichinter > 0) {
+				$fi = new Fichinter($db);
+				if ($fi->fetch($target_fichinter) > 0) {
+					$fi->fetch_optionals();
+					$fi->array_options['options_gestionparc_'.$gp_field] = $gp_value ? $gp_value : '';
+					$fi->updateExtraField('gestionparc_'.$gp_field);
+				}
+			}
+			setEventMessages($langs->trans('gp_users_saved'), null, 'mesgs');
+			header('Location: '.$_SERVER['PHP_SELF'].'?socid='.$socid.'&parctype='.$parctype);
+			exit;
+		}
+		break;
+
+	// ENREGISTRER UN CHAMP PERSONNALISE TIERS (extrafield societe, cases à cocher)
+	case 'gp_set_socfield':
+
+		if (GETPOST('token') != $_SESSION['token']) {
+			$error++; setEventMessages($langs->trans('SecurityTokenHasExpiredSoActionHasBeenCanceledPleaseRetry'), null, 'warnings');
+		}
+		if (!$user->hasRight('gestionparc', 'parc', 'write') && !$user->admin) {
+			$error++; setEventMessages($langs->trans('NotEnoughPermissions'), null, 'warnings');
+		}
+		$gp_fieldkey = GETPOST('gp_fieldkey', 'aZ09');
+		$gp_socfields = GestionParcVerif::getCustomSocFields();
+		if (!isset($gp_socfields[$gp_fieldkey])) {
+			$error++; setEventMessages($langs->trans('gp_error'), null, 'warnings');
+		}
+
+		if (!$error) {
+			// S'assure que les extrafields existent (upgrade-safe)
+			$gpverif_ensure = new GestionParcVerif($db);
+			$gpverif_ensure->ensureSocieteExtrafields();
+
+			$valid_keys = array_keys($gp_socfields[$gp_fieldkey]['options']);
+			$posted = GETPOST('gp_socfield', 'array');
+			$selected = array();
+			foreach ((array) $posted as $optk) {
+				if (in_array($optk, $valid_keys, true)) $selected[] = $optk;
+			}
+
+			$object->fetch_optionals();
+			$object->array_options['options_'.$gp_fieldkey] = implode(',', $selected);
+			if ($object->updateExtraField($gp_fieldkey) > 0) {
+				setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
+			} else {
+				setEventMessages($object->error, null, 'errors');
+			}
+			header('Location: '.$_SERVER['PHP_SELF'].'?socid='.$socid.'&parctype='.$parctype);
+			exit;
+		}
+		break;
+
 	// CLOSE VERIF
 	case 'close_verif':
 
@@ -117,6 +192,17 @@ switch ($action):
 			if ($t2s <= 0) {
 				$error++; $action = 'initclose_verif';
 				setEventMessages($langs->trans('gp_verif_error_needDuration'), null, 'errors');
+			}
+
+			// Au moins une case doit être cochée sur les champs requis pour valider l'intervention
+			$object->fetch_optionals();
+			foreach (GestionParcVerif::getCustomSocFields() as $gp_fk => $gp_fdef) {
+				if (empty($gp_fdef['required'])) continue;
+				$gp_val = isset($object->array_options['options_'.$gp_fk]) ? trim((string) $object->array_options['options_'.$gp_fk]) : '';
+				if ($gp_val === '') {
+					$error++; $action = 'initclose_verif';
+					setEventMessages($langs->trans('gp_verif_error_needSocField', $langs->transnoentities($gp_fdef['label'])), null, 'errors');
+				}
 			}
 
 			if (!$error) {
@@ -227,6 +313,28 @@ switch ($action):
 			if ($verification->setLineCheck($socid, $gestionparc->parc_key, GETPOST('itemid'), 1, $verification->rowid)) {
 				setEventMessages($langs->trans('gp_verifline_success'), null, 'mesgs');
 				// Redirect to keep position
+				header('Location: '.$_SERVER['PHP_SELF'].'?socid='.$socid.'&parctype='.$parctype.'#item-'.GETPOST('itemid'));
+				exit;
+			} else {
+				$error++; setEventMessages($langs->trans('gp_error'), null, 'warnings');
+			}
+		}
+		break;
+
+	// REVERT : revenir en arrière sur le contrôle d'une ligne (dévérifier)
+	case 'set_line_unverify':
+
+		if (GETPOST('token') != $_SESSION['token']) {
+			$error++; setEventMessages($langs->trans('SecurityTokenHasExpiredSoActionHasBeenCanceledPleaseRetry'), null, 'warnings');
+		}
+		if (empty(GETPOST('socid')))  { $error++; setEventMessages($langs->trans('gp_error_needSocId'), null, 'warnings'); }
+		if (empty(GETPOST('itemid'))) { $error++; setEventMessages($langs->trans('gp_error_needItemId'), null, 'warnings'); }
+		if (empty(GETPOST('parcid'))) { $error++; setEventMessages($langs->trans('gp_error_needTypeId'), null, 'warnings'); }
+
+		if (!$error) {
+			$gestionparc->fetch_parcType(GETPOST('parcid'));
+			if ($verification->setLineCheck($socid, $gestionparc->parc_key, GETPOST('itemid'), 0, $verification->rowid)) {
+				setEventMessages($langs->trans('gp_verifline_reverted'), null, 'mesgs');
 				header('Location: '.$_SERVER['PHP_SELF'].'?socid='.$socid.'&parctype='.$parctype.'#item-'.GETPOST('itemid'));
 				exit;
 			} else {
@@ -804,6 +912,31 @@ print '<div class="park-main-wrapper">';
 	$linkback = '<a href="'.DOL_URL_ROOT.'/societe/list.php?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
 	dol_banner_tab($object, 'socid', $linkback, ($user->socid ? 0 : 1), 'rowid', 'nom');
 
+	// Contexte commercial / intervenant : cible = campagne en cours, sinon dernière intervention
+	$gp_show_users     = false;
+	$gp_can_edit_users = ($user->hasRight('gestionparc', 'parc', 'verif') || $user->admin);
+	$gp_last_inter_id  = 0;
+	$gp_sel_com = 0; $gp_sel_int = 0;
+	$gp_target_hidden = '';
+	if (isModEnabled('intervention') && getDolGlobalInt('MAIN_MODULE_GESTIONPARC_USEVERIF')) {
+		$gp_last_inter_id = $verification->getLastVerif($socid);
+		if ($isModeVerif) {
+			$gp_sel_com = !empty($verification->commercial) ? $verification->commercial : 0;
+			$gp_sel_int = !empty($verification->intervenant) ? $verification->intervenant : 0;
+			$gp_target_hidden = '<input type="hidden" name="gp_verif_id" value="'.$modeVerifID.'">';
+			$gp_show_users = true;
+		} elseif ($gp_last_inter_id) {
+			$gp_inter_tmp = new Fichinter($db);
+			if ($gp_inter_tmp->fetch($gp_last_inter_id) > 0) {
+				$gp_inter_tmp->fetch_optionals();
+				$gp_sel_com = !empty($gp_inter_tmp->array_options['options_gestionparc_commercial']) ? $gp_inter_tmp->array_options['options_gestionparc_commercial'] : 0;
+				$gp_sel_int = !empty($gp_inter_tmp->array_options['options_gestionparc_intervenant']) ? $gp_inter_tmp->array_options['options_gestionparc_intervenant'] : 0;
+			}
+			$gp_target_hidden = '<input type="hidden" name="gp_fichinter_id" value="'.$gp_last_inter_id.'">';
+			$gp_show_users = true;
+		}
+	}
+
 	//
 	print '<div class="fichecenter">';
 		print '<div class="fichehalfleft">';
@@ -839,6 +972,81 @@ print '<div class="park-main-wrapper">';
 							print '</td>';
 						print '</tr>';
 					}
+					// Champs personnalisés tiers (extrafields societe, gérés uniquement depuis cet onglet)
+					$object->fetch_optionals();
+					$gp_can_edit_socf = ($user->hasRight('gestionparc', 'parc', 'write') || $user->admin);
+					foreach (GestionParcVerif::getCustomSocFields() as $gp_fk => $gp_fdef) {
+						$gp_f_options  = $gp_fdef['options'];
+						$gp_f_value    = isset($object->array_options['options_'.$gp_fk]) ? $object->array_options['options_'.$gp_fk] : '';
+						$gp_f_selected = array_filter(array_map('trim', explode(',', (string) $gp_f_value)));
+						$gp_f_editing  = ($action == 'gp_edit_socfield' && GETPOST('gp_fieldkey', 'aZ09') == $gp_fk);
+						print '<tr>';
+							print '<td class="titlefieldmiddle">'.$langs->trans($gp_fdef['label']).'</td>';
+							print '<td>';
+							if ($gp_f_editing && $gp_can_edit_socf) {
+								print '<form action="'.$_SERVER["PHP_SELF"].'?socid='.$object->id.'&parctype='.$parctype.'" method="POST">';
+								print '<input type="hidden" name="token" value="'.newToken().'">';
+								print '<input type="hidden" name="action" value="gp_set_socfield">';
+								print '<input type="hidden" name="gp_fieldkey" value="'.$gp_fk.'">';
+								foreach ($gp_f_options as $gp_optk => $gp_optlabel) {
+									$gp_chk = in_array($gp_optk, $gp_f_selected, true) ? ' checked' : '';
+									print '<label class="marginrightonly"><input type="checkbox" name="gp_socfield[]" value="'.$gp_optk.'"'.$gp_chk.'> '.$gp_optlabel.'</label> ';
+								}
+								print '<input type="submit" class="button smallpaddingimp small nomarginleft" value="'.$langs->trans('Save').'">';
+								print '</form>';
+							} else {
+								if (!empty($gp_f_selected)) {
+									$gp_f_labels = array();
+									foreach ($gp_f_selected as $gp_optk) {
+										$gp_f_labels[] = isset($gp_f_options[$gp_optk]) ? $gp_f_options[$gp_optk] : $gp_optk;
+									}
+									print dol_escape_htmltag(implode(', ', $gp_f_labels));
+								} else {
+									print '<span class="opacitymedium">'.$langs->trans('None').'</span>';
+								}
+								if ($gp_can_edit_socf) {
+									print ' <a class="editfielda" href="'.$_SERVER["PHP_SELF"].'?socid='.$object->id.'&parctype='.$parctype.'&action=gp_edit_socfield&gp_fieldkey='.$gp_fk.'">'.img_edit().'</a>';
+								}
+							}
+							print '</td>';
+						print '</tr>';
+					}
+					// Commercial / Intervenant : un champ par ligne, édition inline au crayon (comme sur la fiche d'intervention)
+					if ($gp_show_users) {
+						$gp_fields = array(
+							'commercial'  => array($langs->trans('gp_extrafieldFichInter_commercial'),  $gp_sel_com),
+							'intervenant' => array($langs->trans('gp_extrafieldFichInter_intervenant'), $gp_sel_int),
+						);
+						foreach ($gp_fields as $gp_fk => $gp_fd) {
+							$gp_editing = ($action == 'gp_edit_user' && GETPOST('gp_field', 'aZ09') == $gp_fk);
+							print '<tr>';
+								print '<td class="titlefieldmiddle">'.$gp_fd[0].'</td>';
+								print '<td>';
+								if ($gp_editing && $gp_can_edit_users) {
+									print '<form action="'.$_SERVER["PHP_SELF"].'?socid='.$object->id.'&parctype='.$parctype.'" method="POST">';
+									print '<input type="hidden" name="token" value="'.newToken().'">';
+									print '<input type="hidden" name="action" value="gp_set_user">';
+									print '<input type="hidden" name="gp_field" value="'.$gp_fk.'">';
+									print $gp_target_hidden;
+									print $form->select_dolusers($gp_fd[1], 'gp_value', 1, null, 0, '', '', $conf->entity, 0, 0, '', 0, '', 'maxwidth200');
+									print ' <input type="submit" class="button smallpaddingimp small nomarginleft" value="'.$langs->trans('Save').'">';
+									print '</form>';
+								} else {
+									if (!empty($gp_fd[1])) {
+										$gp_u = new User($db);
+										if ($gp_u->fetch($gp_fd[1]) > 0) { print $gp_u->getNomUrl(1); }
+										else { print '&mdash;'; }
+									} else {
+										print '<span class="opacitymedium">'.$langs->trans('None').'</span>';
+									}
+									if ($gp_can_edit_users) {
+										print ' <a class="editfielda" href="'.$_SERVER["PHP_SELF"].'?socid='.$object->id.'&parctype='.$parctype.'&action=gp_edit_user&gp_field='.$gp_fk.'">'.img_edit().'</a>';
+									}
+								}
+								print '</td>';
+							print '</tr>';
+						}
+					}
 				print '</tbody>';
 			print '</table>';
 		print '</div>';
@@ -848,7 +1056,7 @@ print '<div class="park-main-wrapper">';
 				print '<tbody>';
 				if (isModEnabled('intervention') && getDolGlobalInt('MAIN_MODULE_GESTIONPARC_USEVERIF')) {
 					// todo: link intervention with table element_element
-					$last_intervention = $verification->getLastVerif($socid);
+					$last_intervention = $gp_last_inter_id;
 					if ($last_intervention) {
 						$ficheinter->fetch($last_intervention);
 						print '<tr>';
@@ -868,11 +1076,14 @@ print '<div class="park-main-wrapper">';
 							print '<td valign="middle">'.$langs->trans('gp_client_verifmode').'</td>';
 							print '<td>';
 							if ($isModeVerif) {
-								print '<form action="'.$_SERVER["PHP_SELF"].'?socid='.$object->id.'&parctype='.$parctype.'" method="POST">';
+								// Si tous les organes ne sont pas contrôlés, le bouton ouvre une
+								// modale de confirmation (gérée en JS) au lieu de clôturer directement.
+								$gp_uncontrolled = ($verification->nb_verified < $verification->nb_total) ? 1 : 0;
+								print '<form id="gp-close-verif-form" action="'.$_SERVER["PHP_SELF"].'?socid='.$object->id.'&parctype='.$parctype.'" method="POST">';
 									print '<input type="hidden" name="token" value="'.newToken().'">';
 									print '<input type="hidden" name="verif_id" value="'.$modeVerifID.'">';
 									print '<input type="hidden" name="action" value="initclose_verif">';
-									print '<input type="submit" name="close" value="'.$langs->trans('gp_verif_close').'" class="button smallpaddingimp small nomarginleft">';
+									print '<input type="submit" name="close" value="'.$langs->trans('gp_verif_close').'" class="button smallpaddingimp small nomarginleft gp-close-verif-btn" data-uncontrolled="'.$gp_uncontrolled.'">';
 									print '<input type="submit" name="cancel_verif" value="'.$langs->trans('gp_verif_cancel').'" class="button butActionDelete cancel smallpaddingimp small nomarginleft" >';
 								print '</form>';
 							} else {
@@ -1046,7 +1257,13 @@ if ((int) $gestionparc->rowid > 0) {
 						print '</div>';
 						print '</form>';
 					} else if ($isModeVerif && $linecontent->verif) {
-						print '<div class="button-verify verified" >Élement vérifié</div>';
+						// Élément contrôlé : cliquer permet de revenir en arrière (revert)
+						$gp_is_manual = (getDolGlobalString('GESTIONPARC_VERIF_MODE') == 'manual');
+						$gp_editurl = $_SERVER['PHP_SELF'].'?socid='.$socid.'&parctype='.$parc->parc_key.'&action=edit&itemid='.$linecontent->rowid.'&parcid='.$parc->rowid.'&fromverif=1&token='.newToken().'#item-'.$linecontent->rowid;
+						print '<a class="button-verify verified js-revert-item" href="#" title="'.dol_escape_htmltag($langs->trans('gp_verif_revert')).'" data-itemid="'.$linecontent->rowid.'" data-parcid="'.$parc->rowid.'" data-socid="'.$object->id.'" data-parctype="'.$parctype.'" data-mode="'.($gp_is_manual ? 'manual' : 'instant').'" data-editurl="'.dol_escape_htmltag($gp_editurl).'">';
+							print '<span class="gp-verified-label"><span class="fas fa-check"></span> '.$langs->trans('gp_verif_verified').'</span>';
+							print '<span class="gp-revert-hint"><span class="fas fa-undo"></span> '.$langs->trans('gp_verif_revert').'</span>';
+						print '</a>';
 					} else if ($isModeVerif && !$linecontent->verif) {
 						// Mode de vérification : manuel ou instantané
 						if (getDolGlobalString('GESTIONPARC_VERIF_MODE') == 'manual') {
@@ -1094,7 +1311,10 @@ if ((int) $gestionparc->rowid > 0) {
 							print '<td class="verify-cell">';
 							if ($action != "edit" || $action == "edit" && $editItem_id != $linecontent->rowid) {
 								if ($linecontent->verif) {
-									echo img_picto($langs->trans("Activated"), 'check-square');
+									// Cliquer permet de revenir en arrière (revert)
+									$gp_is_manual = (getDolGlobalString('GESTIONPARC_VERIF_MODE') == 'manual');
+									$gp_editurl = $_SERVER['PHP_SELF'].'?socid='.$socid.'&parctype='.$parc->parc_key.'&action=edit&itemid='.$linecontent->rowid.'&parcid='.$parc->rowid.'&fromverif=1&token='.newToken().'#item-'.$linecontent->rowid;
+									echo '<a class="reposition js-revert-item-list" href="#" title="'.dol_escape_htmltag($langs->trans('gp_verif_revert')).'" data-itemid="'.$linecontent->rowid.'" data-parcid="'.$parc->rowid.'" data-socid="'.$object->id.'" data-parctype="'.$parctype.'" data-mode="'.($gp_is_manual ? 'manual' : 'instant').'" data-editurl="'.dol_escape_htmltag($gp_editurl).'">'.img_picto($langs->trans("Activated"), 'check-square').'</a>';
 								} else {
 									// Mode de vérification : manuel ou instantané
 									if (getDolGlobalString('GESTIONPARC_VERIF_MODE') == 'manual') {
@@ -1308,92 +1528,176 @@ $(function() {
 		itemHeader.toggleClass('menu-open');
 	});
 
-	// Vérifier un élément en AJAX (vue cards)
+	// Libellés (i18n)
+	var GP_TXT_VERIFY   = <?php echo json_encode($langs->transnoentities('gp_verif_verify')); ?>;
+	var GP_TXT_VERIFIED = <?php echo json_encode($langs->transnoentities('gp_verif_verified')); ?>;
+	var GP_TXT_REVERT   = <?php echo json_encode($langs->transnoentities('gp_verif_revert')); ?>;
+	var GP_VERIFY_URL   = '<?php echo dol_buildpath('/gestionparc/ajax/verify-items.php', 1); ?>';
+	var GP_TOKEN        = '<?php echo newToken(); ?>';
+
+	// Construit le bouton "élément vérifié" (cliquable pour revert)
+	function gpVerifiedBtn(d) {
+		var $b = $('<a class="button-verify verified js-revert-item" href="#"></a>')
+			.attr('title', GP_TXT_REVERT)
+			.attr('data-itemid', d.itemId).attr('data-parcid', d.parcId)
+			.attr('data-socid', d.socId).attr('data-parctype', d.parcType)
+			.attr('data-mode', d.mode).attr('data-editurl', d.editUrl || '');
+		$b.append($('<span class="gp-verified-label"><span class="fas fa-check"></span> </span>').append(document.createTextNode(GP_TXT_VERIFIED)));
+		$b.append($('<span class="gp-revert-hint"><span class="fas fa-undo"></span> </span>').append(document.createTextNode(GP_TXT_REVERT)));
+		return $b;
+	}
+	// Construit le bouton "Vérifier" (non vérifié) selon le mode
+	function gpUnverifiedBtn(d) {
+		if (d.mode === 'manual') {
+			return $('<a class="button-verify unverified"></a>').attr('href', d.editUrl).text(GP_TXT_VERIFY);
+		}
+		return $('<a class="button-verify unverified js-verify-item" href="#"></a>')
+			.attr('data-itemid', d.itemId).attr('data-parcid', d.parcId)
+			.attr('data-socid', d.socId).attr('data-parctype', d.parcType).text(GP_TXT_VERIFY);
+	}
+
+	// Vérifier un élément en AJAX (vue cards) — mode instantané
 	$(document).on('click', '.js-verify-item', function(e) {
 		e.preventDefault();
-		
+
 		var $btn = $(this);
-		var itemId = $btn.data('itemid');
-		var parcId = $btn.data('parcid');
-		var socId = $btn.data('socid');
-		var parcType = $btn.data('parctype');
-		
+		var d = { itemId: $btn.data('itemid'), parcId: $btn.data('parcid'), socId: $btn.data('socid'), parcType: $btn.data('parctype'), mode: 'instant', editUrl: '' };
+
 		// Désactiver le bouton pendant le traitement
-		$btn.prop('disabled', true).text('Vérification...');
-		
+		$btn.css('pointer-events', 'none').text('Vérification...');
+
 		$.ajax({
-			url: '<?php echo dol_buildpath('/gestionparc/ajax/verify-items.php', 1); ?>',
+			url: GP_VERIFY_URL,
 			type: 'POST',
 			dataType: 'json',
-			data: {
-				action: 'set_line_verify',
-				itemid: itemId,
-				parcid: parcId,
-				socid: socId,
-				parctype: parcType,
-				token: '<?php echo newToken(); ?>'
-			},
+			data: { action: 'set_line_verify', itemid: d.itemId, parcid: d.parcId, socid: d.socId, parctype: d.parcType, token: GP_TOKEN },
 			success: function(response) {
 				if (response.success) {
-					// Remplacer le bouton par le statut vérifié
-					$btn.replaceWith('<div class="button-verify verified">Élement vérifié</div>');
-					
-					// Mettre à jour l'icône dans le header de la carte
-					var $item = $('#item-' + itemId);
+					$btn.replaceWith(gpVerifiedBtn(d));
+					var $item = $('#item-' + d.itemId);
 					$item.removeClass('unverified').addClass('verified');
-					
-					// Changer l'icône de warning à check
 					var $icon = $item.find('.park-item-header .fa-exclamation-circle');
 					if ($icon.length) {
-						$icon.removeClass('fa-exclamation-circle text-warning')
-							.addClass('fa-check-circle text-success');
+						$icon.removeClass('fa-exclamation-circle text-warning').addClass('fa-check-circle text-success');
 					}
 				} else {
-					$btn.prop('disabled', false).text('Vérifier');
+					$btn.css('pointer-events', 'auto').text(GP_TXT_VERIFY);
 					console.error('Erreur:', response.error);
 				}
 			},
 			error: function(xhr, status, error) {
-				$btn.prop('disabled', false).text('Vérifier');
+				$btn.css('pointer-events', 'auto').text(GP_TXT_VERIFY);
+				console.error('Erreur AJAX:', error);
+			}
+		});
+	});
+
+	// Revert (revenir en arrière) sur un élément contrôlé — vue cards (tous modes)
+	$(document).on('click', '.js-revert-item', function(e) {
+		e.preventDefault();
+
+		var $btn = $(this);
+		var d = { itemId: $btn.data('itemid'), parcId: $btn.data('parcid'), socId: $btn.data('socid'), parcType: $btn.data('parctype'), mode: $btn.data('mode'), editUrl: $btn.data('editurl') };
+
+		$btn.css('pointer-events', 'none').css('opacity', '0.6');
+
+		$.ajax({
+			url: GP_VERIFY_URL,
+			type: 'POST',
+			dataType: 'json',
+			data: { action: 'set_line_unverify', itemid: d.itemId, parcid: d.parcId, socid: d.socId, parctype: d.parcType, token: GP_TOKEN },
+			success: function(response) {
+				if (response.success) {
+					$btn.replaceWith(gpUnverifiedBtn(d));
+					var $item = $('#item-' + d.itemId);
+					$item.removeClass('verified').addClass('unverified');
+					var $icon = $item.find('.park-item-header .fa-check-circle');
+					if ($icon.length) {
+						$icon.removeClass('fa-check-circle text-success').addClass('fa-exclamation-circle text-warning');
+					}
+				} else {
+					$btn.css('pointer-events', 'auto').css('opacity', '1');
+					console.error('Erreur:', response.error);
+				}
+			},
+			error: function(xhr, status, error) {
+				$btn.css('pointer-events', 'auto').css('opacity', '1');
 				console.error('Erreur AJAX:', error);
 			}
 		});
 	});
 
 	// Vérifier un élément en AJAX (vue liste)
+	// Icônes (vue liste)
+	var GP_ICON_CHECK  = <?php echo json_encode(img_picto($langs->transnoentities('Activated'), 'check-square')); ?>;
+	var GP_ICON_SWITCH = <?php echo json_encode(img_picto($langs->transnoentities('Disabled'), 'switch_off')); ?>;
+
+	function gpListVerifiedLink(d) {
+		return $('<a class="reposition js-revert-item-list" href="#"></a>')
+			.attr('title', GP_TXT_REVERT)
+			.attr('data-itemid', d.itemId).attr('data-parcid', d.parcId)
+			.attr('data-socid', d.socId).attr('data-parctype', d.parcType)
+			.attr('data-mode', d.mode).attr('data-editurl', d.editUrl || '')
+			.html(GP_ICON_CHECK);
+	}
+	function gpListUnverifiedLink(d) {
+		if (d.mode === 'manual') {
+			return $('<a class="reposition"></a>').attr('href', d.editUrl).html(GP_ICON_SWITCH);
+		}
+		return $('<a class="reposition js-verify-item-list" href="#"></a>')
+			.attr('data-itemid', d.itemId).attr('data-parcid', d.parcId)
+			.attr('data-socid', d.socId).attr('data-parctype', d.parcType)
+			.html(GP_ICON_SWITCH);
+	}
+
 	$(document).on('click', '.js-verify-item-list', function(e) {
 		e.preventDefault();
-		
+
 		var $link = $(this);
-		var itemId = $link.data('itemid');
-		var parcId = $link.data('parcid');
-		var socId = $link.data('socid');
-		var parcType = $link.data('parctype');
-		
-		// Désactiver le lien pendant le traitement
+		var d = { itemId: $link.data('itemid'), parcId: $link.data('parcid'), socId: $link.data('socid'), parcType: $link.data('parctype'), mode: 'instant', editUrl: '' };
+
 		$link.css('pointer-events', 'none').css('opacity', '0.5');
-		
+
 		$.ajax({
-			url: '<?php echo dol_buildpath('/gestionparc/ajax/verify-items.php', 1); ?>',
+			url: GP_VERIFY_URL,
 			type: 'POST',
 			dataType: 'json',
-			data: {
-				action: 'set_line_verify',
-				itemid: itemId,
-				parcid: parcId,
-				socid: socId,
-				parctype: parcType,
-				token: '<?php echo newToken(); ?>'
-			},
+			data: { action: 'set_line_verify', itemid: d.itemId, parcid: d.parcId, socid: d.socId, parctype: d.parcType, token: GP_TOKEN },
 			success: function(response) {
 				if (response.success) {
-					// Remplacer l'icône par check-square
-					var $cell = $link.closest('.verify-cell');
-					$cell.html('<?php echo img_picto($langs->trans("Activated"), "check-square"); ?>');
-					
-					// Ajouter la classe parcline-ok à la ligne
-					var $row = $('#item-' + itemId);
-					$row.addClass('parcline-ok');
+					$link.closest('.verify-cell').empty().append(gpListVerifiedLink(d));
+					$('#item-' + d.itemId).addClass('parcline-ok');
+				} else {
+					$link.css('pointer-events', 'auto').css('opacity', '1');
+					console.error('Erreur:', response.error);
+				}
+			},
+			error: function(xhr, status, error) {
+				$link.css('pointer-events', 'auto').css('opacity', '1');
+				console.error('Erreur AJAX:', error);
+			}
+		});
+	});
+
+	// Revert (revenir en arrière) — vue liste (tous modes)
+	$(document).on('click', '.js-revert-item-list', function(e) {
+		e.preventDefault();
+
+		var $link = $(this);
+		var $cell = $link.closest('.verify-cell');
+		var d = { itemId: $link.data('itemid'), parcId: $link.data('parcid'), socId: $link.data('socid'), parcType: $link.data('parctype'), mode: $link.data('mode'), editUrl: $link.data('editurl') };
+
+		$link.css('pointer-events', 'none').css('opacity', '0.5');
+
+		$.ajax({
+			url: GP_VERIFY_URL,
+			type: 'POST',
+			dataType: 'json',
+			data: { action: 'set_line_unverify', itemid: d.itemId, parcid: d.parcId, socid: d.socId, parctype: d.parcType, token: GP_TOKEN },
+			success: function(response) {
+				if (response.success) {
+					$cell.empty().append(gpListUnverifiedLink(d));
+					$('#item-' + d.itemId).removeClass('parcline-ok');
 				} else {
 					$link.css('pointer-events', 'auto').css('opacity', '1');
 					console.error('Erreur:', response.error);
@@ -1568,6 +1872,7 @@ $(function() {
             stop: function(event, ui) {
 	            // Récupérer l'ordre des éléments après le drag & drop
 	            var sortedIDs = $(this).sortable("toArray");
+	            var movedItem = ui.item.attr('id'); // élément réellement déplacé
 
 	            // Appel AJAX pour sauvegarder l'ordre
 	            $.ajax({
@@ -1576,6 +1881,7 @@ $(function() {
 	                data: {
 	                	action: 'itemsort',
 	                	itemsort: sortedIDs,
+	                	moveditem: movedItem,
 	                	parckey: '<?php echo $parc->parc_key; ?>',
 	                	token: '<?php echo newToken(); ?>',
 	                },
@@ -1623,10 +1929,50 @@ $(function() {
 	</div>
 </div>
 
+<!-- Modale de confirmation : clôture avec organes non contrôlés -->
+<div id="gp-confirm-close-overlay" class="gp-modal-overlay" style="display:none;">
+	<div class="gp-modal-container gp-modal-sm">
+		<div class="gp-modal-header">
+			<h3><?php echo $langs->trans('gp_verif_uncontrolled_title'); ?></h3>
+			<span class="gp-modal-close">&times;</span>
+		</div>
+		<div class="gp-modal-body">
+			<p class="gp-modal-desc"><i class="fas fa-exclamation-triangle"></i> <?php echo $langs->trans('gp_verif_confirm_uncontrolled'); ?></p>
+		</div>
+		<div class="gp-modal-footer gp-modal-footer-split">
+			<button type="button" class="button gp-modal-close-btn" id="gp-confirm-close-no"><?php echo $langs->trans('No'); ?></button>
+			<button type="button" class="button gp-modal-btn-primary" id="gp-confirm-close-yes"><?php echo $langs->trans('gp_verif_continue_anyway'); ?></button>
+		</div>
+	</div>
+</div>
+
 <script>
 	const GP_EXPORT_BASE_URL = '<?php echo $_SERVER['PHP_SELF'].'?socid='.$socid.'&action=generate_export_excel&token='.newToken().'&id_inter='; ?>';
 	const GP_EXPORT_PDF_BASE_URL = '<?php echo $_SERVER['PHP_SELF'].'?socid='.$socid.'&action=generate_export_pdf&token='.newToken().'&id_inter='; ?>';
 
+	// Modale de confirmation de clôture (organes non contrôlés)
+	jQuery(document).on('click', '.gp-close-verif-btn', function(e) {
+		if (parseInt(jQuery(this).attr('data-uncontrolled'), 10) === 1) {
+			e.preventDefault();
+			jQuery('#gp-confirm-close-overlay').fadeIn(200);
+			jQuery('body').css('overflow', 'hidden');
+		}
+	});
+	jQuery(document).on('click', '#gp-confirm-close-yes', function() {
+		jQuery('#gp-confirm-close-overlay').fadeOut(100);
+		jQuery('body').css('overflow', '');
+		jQuery('#gp-close-verif-form').trigger('submit');
+	});
+	jQuery(document).on('click', '#gp-confirm-close-no, #gp-confirm-close-overlay .gp-modal-close', function() {
+		jQuery('#gp-confirm-close-overlay').fadeOut(200);
+		jQuery('body').css('overflow', '');
+	});
+	jQuery(document).on('click', '#gp-confirm-close-overlay', function(e) {
+		if (jQuery(e.target).hasClass('gp-modal-overlay')) {
+			jQuery(this).fadeOut(200);
+			jQuery('body').css('overflow', '');
+		}
+	});
 </script>
 
 <?php


### PR DESCRIPTION
Version 1.9.0 — passage sur la branche `1.9.x`.

## Nouveautés
- Champs tiers **« Référentiel de conformité »** (APSAD R4 / Code du Travail) et **« Type de plan »** (Plan de sécurité / d'intervention / d'évacuation / Sans) : saisis dans l'onglet GestionParc, figés sur l'intervention à la clôture, affichés en bas du header des exports ; au moins une case requise pour clôturer.
- **Snapshot des vérifications à la clôture** : l'export d'une vérif passée reflète les données de l'époque (et plus les données live). Page Réparation pour **reconstruire l'historique** des anciennes vérifs depuis les XLSX (+ `scripts/backport_snapshots.php`).
- **Tri par numérotation** par défaut des organes ; seuls les organes déplacés manuellement gardent leur position (désépinglage au retour en ordre naturel).
- **Mode revert** : dévérifier un organe en un clic pendant un contrôle.
- **Pop-up de confirmation** à la clôture si des organes ne sont pas contrôlés.
- **Restauration** des champs réinitialisés (ex. Observations) si la vérif est annulée.

## Améliorations / Corrections
- **PDF** : un organe par page ; bordure et en-têtes de colonnes répétés sur les tableaux multi-pages ; hauteurs de lignes correctes (plus de troncature ni d'artefact).
- **Excel** : tous les tableaux à la même largeur ; retour à la ligne + hauteur adaptée ; libellés d'en-tête longs non coupés.
- Défauts commercial/technicien repris de la précédente intervention (plus d'écrasement au lancement de la vérif).
- Curseur pointer sur les boutons de vérification.

Détail complet dans `ChangeLog.md`.
